### PR TITLE
Add ACF Fields to "Types" based on FieldGroup location rules

### DIFF
--- a/src/Actions.php
+++ b/src/Actions.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace WPGraphQL\Extensions\ACF;
+
+use WPGraphQL\Extensions\ACF\Types as ACFTypes;
+use WPGraphQL\Extensions\ACF\Utils as ACFUtils;
+
+class Actions {
+
+	/**
+	 * This adds the ACF fields to each type, based on ACF Field Group location rules.
+	 *
+	 * @return mixed
+	 */
+	public static function acf_add_fields_to_types() {
+
+		/**
+		 * Get the registered_field_groups
+		 */
+		$field_groups = acf_get_field_groups();
+
+		/**
+		 * If there are registered $field_groups
+		 */
+		if ( ! empty( $field_groups ) && is_array( $field_groups ) ) {
+
+			/**
+			 * Loop through the field_groups
+			 */
+			foreach ( $field_groups as $field_group ) {
+
+				/**
+				 * Get the field group location rules
+				 */
+				$locations = $field_group['location'];
+
+				/**
+				 * If the field group has location rules defined
+				 */
+				if ( ! empty( $locations ) && is_array( $locations ) ) {
+
+					/**
+					 * Loop through the location rules
+					 */
+					foreach ( $locations as $location ) {
+
+						/**
+						 * Setup the fields for each type, based on the param that's setting them up
+						 */
+						switch ( $location[0]['param'] ) {
+
+							case 'post_type':
+								self::post_object_fields( $location, $field_group );
+								break;
+							case 'taxonomy':
+								self::term_object_fields( $location, $field_group );
+								break;
+							default:
+								break;
+
+						} // End switch().
+					}// End foreach().
+				}// End if().
+			}// End foreach().
+		}// End if().
+		return;
+	}
+
+	/**
+	 *
+	 * @param $location
+	 * @param $field_group
+	 */
+	private static function post_object_fields( $location, $field_group ) {
+
+		/**
+		 * If the rule is for a post_type that's in the GraphQL allowed_post_types, and
+		 */
+		if ( '==' === $location[0]['operator'] && in_array( $location[0]['value'], \WPGraphQL::get_allowed_post_types(), true ) ) {
+
+			/**
+			 * Get the post_type_object
+			 */
+			$post_type_object = ! empty( $location[0]['value'] ) ? get_post_type_object( $location[0]['value'] ) : null;
+
+			/**
+			 * If the post_type_object has a graphql_single_name defined
+			 */
+			if ( ! empty( $post_type_object->graphql_single_name ) ) {
+
+				/**
+				 * Filter the fields for that type to apply the fields that have been registered by ACF
+				 */
+				add_filter( "graphql_{$post_type_object->graphql_single_name}_fields", function( $fields ) use ( $field_group ) {
+					return self::filter_object_fields( $fields, $field_group );
+				}, 10, 1 );
+			}
+		}
+
+	}
+
+	private static function term_object_fields( $location, $field_group ) {
+
+		if ( '==' === $location[0]['operator'] &&  in_array( $location[0]['value'], \WPGraphQL::get_allowed_taxonomies(), true ) ) {
+			$taxonomy_object = ! empty( $location[0]['value'] ) ? get_taxonomy( $location[0]['value'] ) : null;
+
+			if ( ! empty( $taxonomy_object->graphql_single_name ) ) {
+
+				add_filter( "graphql_{$taxonomy_object->graphql_single_name}_fields", function( $fields ) use ( $field_group ) {
+					return self::filter_object_fields( $fields, $field_group );
+				}, 10, 1 );
+
+			}
+		}
+
+	}
+
+	public static function filter_object_fields( $fields, $field_group ) {
+
+		/**
+		 * Get the fields for the specified field_group
+		 */
+		$acf_fields = acf_get_fields( $field_group['ID'] );
+
+		/**
+		 * Check to see if there are fields defined for the field group
+		 */
+		if ( ! empty( $acf_fields ) && is_array( $acf_fields ) ) {
+
+			/**
+			 * Loop through the configured fields
+			 */
+			foreach ( $acf_fields as $acf_field ) {
+
+				/**
+				 * If the field has a label we can safely add to the schema
+				 */
+				if ( ! empty( $acf_field['graphql_label'] ) ) {
+
+					/**
+					 * Get the field_type
+					 */
+					$type = (array) acf_get_field_type( $acf_field['type'] );
+
+					/**
+					 * Add a "graphql_label" to the field type for use in instantiating the
+					 */
+					$type['graphql_label'] = ACFUtils::_graphql_label( $type['name'] );
+
+					$fields[ $acf_field['graphql_label'] ] = [
+						'type'        => ACFTypes::field_type( $type ),
+						// Translators: The placeholder is the type of object (post_type, taxonomy, etc) being filtered
+						'description' => sprintf( __( 'The %1$s field', 'wp-graphql-acf' ), $acf_field['label'] ),
+						'resolve'     => function( \WP_Post $post ) use ( $acf_field, $type ) {
+							$acf_field['object_id'] = $post->ID;
+							return $acf_field;
+						},
+					];
+				}
+			}
+		}
+
+		return $fields;
+
+	}
+
+}

--- a/src/Actions.php
+++ b/src/Actions.php
@@ -151,8 +151,16 @@ class Actions {
 						'type'        => ACFTypes::field_type( $type ),
 						// Translators: The placeholder is the type of object (post_type, taxonomy, etc) being filtered
 						'description' => sprintf( __( 'The %1$s field', 'wp-graphql-acf' ), $acf_field['label'] ),
-						'resolve'     => function( \WP_Post $post ) use ( $acf_field, $type ) {
-							$acf_field['object_id'] = $post->ID;
+						'resolve'     => function( $resolving_object ) use ( $acf_field, $type ) {
+
+							$object_id = '';
+							if ( $resolving_object instanceof \WP_Post ) {
+								$object_id = $resolving_object->ID;
+							} elseif ( $resolving_object instanceof \WP_Term ) {
+								$object_id = $resolving_object->taxonomy . '_' . $resolving_object->term_id;
+							}
+
+							$acf_field['object_id'] = $object_id;
 							return $acf_field;
 						},
 					];

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -4,22 +4,22 @@ namespace WPGraphQL\Extensions\ACF;
 
 use GraphQL\Type\Definition\ResolveInfo;
 use WPGraphQL\AppContext;
+use WPGraphQL\Extensions\ACF\Utils as ACFUtils;
 
 class Filters {
 
-	public static function _graphql_label( $input ) {
-
-		$graphql_label = str_ireplace( '_', ' ', $input );
-		$graphql_label = ucwords( $graphql_label );
-		$graphql_label = str_ireplace( ' ', '', $graphql_label );
-		$graphql_label = lcfirst( $graphql_label );
-
-		return $graphql_label;
-
-	}
-
+	/**
+	 * Filters the GraphQL root query fields, to add entry points for ACF
+	 *
+	 * @param $fields
+	 *
+	 * @return mixed
+	 */
 	public static function acf_root_query_field_groups( $fields ) {
 
+		/**
+		 * Setup the root query fields for ACF
+		 */
 		$fields['fieldGroups'] = [
 			'type'        => \WPGraphQL\Types::list_of( Types::field_group_type() ),
 			'description' => __( 'Field Groups defined by Advanced Custom Fields', 'wp-graphql-acf' ),
@@ -32,7 +32,13 @@ class Filters {
 
 	}
 
-
+	/**
+	 * Adds a "graphql_label" to each field when acf_get_fields() is called
+	 *
+	 * @param $fields
+	 *
+	 * @return array
+	 */
 	public static function acf_get_fields( $fields ) {
 
 		if ( empty( $fields ) || ! is_array( $fields ) ) {
@@ -41,7 +47,7 @@ class Filters {
 
 		foreach ( $fields as $key => $field ) {
 
-			$graphql_label                   = self::_graphql_label( $field['type'] );
+			$graphql_label                   = ACFUtils::_graphql_label( $field['name'] );
 			$fields[ $key ]['graphql_label'] = $graphql_label . 'Field';
 
 		}
@@ -49,6 +55,13 @@ class Filters {
 		return $fields;
 	}
 
+	/**
+	 * Adds a "graphql_label" to each field type that's returned when acf_get_field_types() is called
+	 *
+	 * @param $types
+	 *
+	 * @return array
+	 */
 	public function acf_field_types( $types ) {
 
 		if ( empty( $types ) || ! is_array( $types ) ) {
@@ -57,7 +70,7 @@ class Filters {
 
 		foreach ( $types as $type_key => $type ) {
 
-			$graphql_label                       = self::_graphql_label( $type['name'] );
+			$graphql_label                       = ACFUtils::_graphql_label( $type['name'] );
 			$types[ $type_key ]['graphql_label'] = $graphql_label . 'Field';
 
 		}
@@ -65,5 +78,4 @@ class Filters {
 		return $types;
 
 	}
-
 }

--- a/src/Type/Field/FieldType.php
+++ b/src/Type/Field/FieldType.php
@@ -20,7 +20,7 @@ class FieldType extends WPObjectType {
 		 * Set the name of the field
 		 */
 		self::$type = $type;
-		self::$type_name = ! empty( self::$type['graphql_label'] ) ? self::$type['graphql_label'] : null;
+		self::$type_name = ! empty( self::$type['graphql_label'] ) ? 'acf' . ucwords( self::$type['graphql_label'] ) . 'Field' : null;
 
 		/**
 		 * Merge the fields passed through the config with the default fields
@@ -77,9 +77,12 @@ class FieldType extends WPObjectType {
 					'prefix' => [
 						'type' => Types::string(),
 					],
-//					'value' => [
-//						'type' => '',
-//					],
+					'value' => [
+						'type' => Types::string(),
+						'resolve' => function( array $field ) {
+							return get_field( $field['key'], $field['object_id'], true );
+						},
+					],
 //					'order' => [],
 					'required' => [
 						'type' => Types::boolean(),

--- a/src/Type/PostTypeObject/PostTypeObject.php
+++ b/src/Type/PostTypeObject/PostTypeObject.php
@@ -1,0 +1,35 @@
+<?php
+namespace WPGraphQL\Extensions\ACF\Type\PostTypeObject;
+
+class PostTypeObject {
+
+	public static function filter_fields( $fields ) {
+
+		$acf_fields = acf_get_fields( $field_group['ID'] );
+
+		if ( ! empty( $acf_fields ) && is_array( $acf_fields ) ) {
+
+			foreach ( $acf_fields as $acf_field ) {
+
+				if ( ! empty( $acf_field['graphql_label'] ) ) {
+
+					$type = (array) acf_get_field_type( $acf_field['type'] );
+					$type['graphql_label'] = self::_graphql_label( $type['name'] );
+
+					$fields[ $acf_field['graphql_label'] ] = [
+						'type'        => Types::field_type( $type ),
+						'description' => sprintf( __( 'The %1$s field', 'wp-graphql-acf' ), $acf_field['label'] ),
+						'resolve'     => function( \WP_Post $post ) use ( $acf_field, $type ) {
+							$acf_field['object_id'] = $post->ID;
+							return $acf_field;
+						},
+					];
+				}
+			}
+		}
+
+		return $fields;
+
+	}
+
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,0 +1,24 @@
+<?php
+namespace WPGraphQL\Extensions\ACF;
+
+class Utils {
+
+	/**
+	 * Utility function for formatting a string to be compatible with GraphQL labels (camelCase with lowercase first letter)
+	 *
+	 * @param $input
+	 *
+	 * @return mixed|string
+	 */
+	public static function _graphql_label( $input ) {
+
+		$graphql_label = str_ireplace( '_', ' ', $input );
+		$graphql_label = ucwords( $graphql_label );
+		$graphql_label = str_ireplace( ' ', '', $graphql_label );
+		$graphql_label = lcfirst( $graphql_label );
+
+		return $graphql_label;
+
+	}
+
+}

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -3,8 +3,8 @@
  * Plugin Name:     WPGraphQL ACF
  * Plugin URI:      https://github.com/tonimain/wp-graphql-acf
  * Description:     Adds Advanced Custom Fields to the WPGraphQL Schema
- * Author:          Toni Main
- * Author URI:      https://tonimain.com
+ * Author:          WPGraphQL, Toni Main, Jason Bahl
+ * Author URI:      https://www.wpgraphql.com
  * Text Domain:     wp-graphql-acf
  * Domain Path:     /languages
  * Version:         0.1.0
@@ -13,9 +13,6 @@
  */
 
 namespace WPGraphQL\Extensions;
-
-// Exit if accessed directly.
-use WPGraphQL\Extensions\ACF\Test;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -133,6 +130,11 @@ if ( ! class_exists( '\WPGraphQL\Extensions\ACF' ) ) :
 		 */
 		private function actions() {
 
+			/**
+			 * Add acf fields to the types registered to GraphQL
+			 */
+			add_action( 'graphql_generate_schema', [ '\WPGraphQL\Extensions\ACF\Actions', 'acf_add_fields_to_types' ] );
+
 		}
 
 		/**
@@ -142,7 +144,8 @@ if ( ! class_exists( '\WPGraphQL\Extensions\ACF' ) ) :
 
 			add_filter( 'graphql_root_queries', [ '\WPGraphQL\Extensions\ACF\Filters', 'acf_root_query_field_groups' ], 10, 1 );
 			add_filter( 'acf/get_field_types', [ '\WPGraphQL\Extensions\ACF\Filters', 'acf_field_types' ], 100 );
-			add_filter( 'acf/get_fields', ['\WPGraphQL\Extensions\ACF\Filters', 'acf_get_fields' ], 100 );
+			add_filter( 'acf/get_fields', [ '\WPGraphQL\Extensions\ACF\Filters', 'acf_get_fields' ], 100 );
+
 		}
 
 	}


### PR DESCRIPTION
This adds fields that have been created by ACF to the respective Types in the GraphQL schema, based on the ACF Field Group rules.

For example, if you create a Field Group and set the location rules to “post_type == post” and create a text field named “Test Field” then the “post” schema in GraphQL should now have a “testField” added to the “post” schema.