### PR TITLE
Show warning in admin when acf is not activated

### DIFF
--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -153,6 +153,17 @@ if ( ! class_exists( '\WPGraphQL\Extensions\ACF' ) ) :
 endif;
 
 function init() {
+    if(!class_exists('acf')) {
+        add_action( 'admin_notices', function() {
+            ?>
+            <div class="error notice">
+                <p><?php _e( 'Advanced custom fields must be active for wp-graphql-acf to work', 'wp-graphiql-acf' ); ?></p>
+            </div>
+            <?php
+        });
+        return false;
+    }
+
 	return ACF::instance();
 }
 


### PR DESCRIPTION
GraphiQL shows an obscure error when acf is not activated. This disables wp-graphql-acf when acf is not enabled and shows a warning in the admin