### PR TITLE
Fix - Null date/times in repeaters

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -361,7 +361,16 @@ class Config {
 				$field_config = [
 					'type'    => 'String',
 					'resolve' => function( $root, $args, $context, $info ) use ( $acf_field ) {
-						return isset( $root->ID ) ? get_field( $acf_field['key'], $root->ID, true ) : null;
+						if (isset($root->ID)) {
+							return get_field($acf_field['key'], $root->ID, true);
+						}
+						//handle sub fields
+						if (isset($root[$acf_field['key']])) {
+							$value = $root[$acf_field['key']];
+							$timestamp = strtotime($value);
+							return date($acf_field['return_format'], $timestamp);
+						}
+						return null;
 					},
 				];
 				break;


### PR DESCRIPTION
Hey, I came across this today, and decided to fix it. Hope it helps.

It looks like the raw values are stored in $root when dealing with sub fields. 

There might be a better way of dealing with the sub fields, but this was what i came up with for the date/time fields. Happy to discuss other options.

#18 