### PR TITLE
Adds a filter for resolving root ID.

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -224,9 +224,17 @@ class Config {
 					$id = 'comment_' . absint( $root->comment_ID );
 					break;
 				default:
-					$id = apply_filters( 'graphql_acf_get_root_id', null, $root );
+					$id = null;
 					break;
 			}
+
+			/**
+			 * For resolving IDs for custom types.
+			 * 
+			 * @param null|integer $id    ID of source object connected to ACF field.
+			 * @param null|mixed   $root  Source object connected to ACF field.
+			 */
+			$id = apply_filters( 'graphql_acf_get_root_id', $id, $root );
 
 			if ( empty( $id ) ) {
 				return null;

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -224,7 +224,7 @@ class Config {
 					$id = 'comment_' . absint( $root->comment_ID );
 					break;
 				default:
-					$id = null;
+					$id = apply_filters( 'graphql_acf_get_root_id', null, $root );
 					break;
 			}
 

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -229,10 +229,10 @@ class Config {
 			}
 
 			/**
-			 * For resolving IDs for custom types.
-			 * 
-			 * @param null|integer $id    ID of source object connected to ACF field.
-			 * @param null|mixed   $root  Source object connected to ACF field.
+			 * Filters the root ID, allowing additional Models the ability to provide a way to resolve their ID
+			 *
+			 * @param int   $id    The ID of the object. Default null
+			 * @param mixed $root  The Root object being resolved. The ID is typically a property of this object.
 			 */
 			$id = apply_filters( 'graphql_acf_get_root_id', $id, $root );
 


### PR DESCRIPTION
This filter allows for custom ID resolving. See example filter below.
```
public static function resolve_crud_root_id( $id, $root ) {
	switch ( true ) {
		case $root instanceof \WPGraphQL\Extensions\WooCommerce\Model\CRUD_CPT:
			$id = absint( $root->ID );
			break;
	}

	return $id;
}
```