### PR TITLE
#48 - Multiple Users ACF field

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -568,14 +568,33 @@ class Config {
 				];
 				break;
 			case 'user':
-				$field_config = [
-					'type'    => 'User',
-					'resolve' => function( $root, $args, $context, $info ) use ( $acf_field ) {
-						$value = $this->get_acf_field_value( $root, $acf_field );
+				if ( 0 === $acf_field['multiple'] ) {
+					$field_config = [
+						'type'    => 'User',
+						'resolve' => function( $root, $args, $context, $info ) use ( $acf_field ) {
+							$value = $this->get_acf_field_value( $root, $acf_field );
+	
+							return DataSource::resolve_user( (int) $value, $context );
+						},
+					];
+				} else {
+					$field_config = [
+						'type'		=> [ 'list_of' => 'User' ],
+						'resolve'	=> function( $root, $args, $context, $info ) use ( $acf_field ) {
+							$value = $this->get_acf_field_value( $root, $acf_field );
 
-						return DataSource::resolve_user( (int) $value, $context );
-					},
-				];
+							$users = [];
+
+							if ( ! empty( $value ) && is_array( $value ) ) {
+								foreach ( $value as $user ) {
+									$users[] = DataSource::resolve_user( (int) $user, $context );
+								}
+							}
+
+							return $users;
+						},
+					];
+				}
 				break;
 			case 'taxonomy':
 				$field_config = [


### PR DESCRIPTION
When querying an ACF User field, check to see if it allows multiple user selection. If so, return array of users. Otherwise, return string.