### PR TITLE
pass the $field_config through a filter

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -318,15 +318,19 @@ class Config {
 			return false;
 		}
 
-		$field_config = [
+		/**
+		 * filter the field config for custom field types
+		 *
+		 * @param array $field_config
+		 */
+		$field_config = apply_filters( 'wpgraphql_acf_register_graphql_field', [
 			'type'    => null,
 			'resolve' => isset( $config['resolve'] ) && is_callable( $config['resolve'] ) ? $config['resolve'] : function( $root, $args, $context, $info ) use ( $acf_field ) {
 				$value = $this->get_acf_field_value( $root, $acf_field );
 
 				return ! empty( $value ) ? $value : null;
 			},
-		];
-
+		], $type_name, $field_name, $config );
 
 		switch ( $acf_type ) {
 			case 'button_group':


### PR DESCRIPTION
This allows the $field_config['type'] to be set for custom field types alongside the `wpgraphql_acf_supported_fields` filter, for example:

```
add_filter( 'wpgraphql_acf_register_graphql_field', function($field_config, $type_name, $field_name, $config) {
  $acf_field = isset( $config['acf_field'] ) ? $config['acf_field'] : null;
  $acf_type  = isset( $acf_field['type'] ) ? $acf_field['type'] : null;
  if ($acf_type == 'font-awesome') {
    $field_config['type'] = 'String';
  }
  return $field_config;
}, 10, 4);
```