### PR TITLE
Fixed allowed post type check

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -499,7 +499,7 @@ class Config {
 					} else {
 						$type_names = [];
 						foreach ( $acf_field['post_type'] as $post_type ) {
-							if ( in_array( $post_type, \WPGraphQL::$allowed_post_types, true ) ) {
+							if ( in_array( $post_type, \WPGraphQL::get_allowed_post_types(), true ) ) {
 								$type_names[ $post_type ] = get_post_type_object( $post_type )->graphql_single_name;
 							}
 						}


### PR DESCRIPTION
Ran into a bug when I upgraded to 0.3.0. Looks like `$allowed_post_types` is null here. Calling the `get_allowed_post_types()` function instead fixed the issue