### PR TITLE
#16 - Fixes taxonomy field to work for single or multiple selections

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -623,7 +623,8 @@ class Config {
 					'resolve' => function( $root, $args, $context, $info ) use ( $acf_field ) {
 						$value = $this->get_acf_field_value( $root, $acf_field );
 						$terms = [];
-						if ( ! empty( $value ) && is_array( $value ) ) {
+						if ( ! empty( $value ) ) {
+							$value = is_array( $value ) ? $value : [ $value ];
 							foreach ( $value as $term ) {
 								$terms[] = DataSource::resolve_term_object( (int) $term, $context );
 							}


### PR DESCRIPTION
This adds support for the `Taxonomy` field to be queried against as a single term or multiple terms.

closes #16 

### Before: 

**Set a single category within the repeater:**

![Screen Shot 2019-11-13 at 11 35 51 AM](https://user-images.githubusercontent.com/1260765/68793165-f306c180-0609-11ea-8875-a130fa758312.png)

**Query returns no category**

![Screen Shot 2019-11-13 at 11 36 26 AM](https://user-images.githubusercontent.com/1260765/68793181-f8640c00-0609-11ea-916a-0c314e44efbc.png)

----

### After

**Set a single category within the repeater:**

![Screen Shot 2019-11-13 at 11 35 51 AM](https://user-images.githubusercontent.com/1260765/68793165-f306c180-0609-11ea-8875-a130fa758312.png)

**Query properly returns category**

![Screen Shot 2019-11-13 at 11 35 01 AM](https://user-images.githubusercontent.com/1260765/68793274-221d3300-060a-11ea-8fa6-e676b633e53a.png)

### Multi Select

**Set multiple categories within the repeater:**
![Screen Shot 2019-11-13 at 11 35 16 AM](https://user-images.githubusercontent.com/1260765/68793323-3a8d4d80-060a-11ea-9fd5-3f6e3995aa93.png)


**Query properly returns multiple categories**
![Screen Shot 2019-11-13 at 11 35 24 AM](https://user-images.githubusercontent.com/1260765/68793335-3fea9800-060a-11ea-9064-48b657023d2a.png)
