### PR TITLE
Add `graphql_field_name` to options pages

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1672,9 +1672,16 @@ class Config {
 			}
 
 			/**
-			 * Create type name
+			 * Create field and type names. Use explicit graphql_field_name
+			 * if available and fallback to generating from title if not available.
 			 */
-			$type_name = ucfirst( Config::camel_case( $page_title ) );
+			if ( ! empty( $options_page['graphql_field_name'] ) ) {
+				$field_name = $options_page['graphql_field_name'];
+				$type_name = ucfirst( $options_page['graphql_field_name'] );
+			} else {
+				$field_name = Config::camel_case( $page_title );
+				$type_name = ucfirst( Config::camel_case( $page_title ) );
+			}
 
 			/**
 			 * Register options page type to schema.
@@ -1706,7 +1713,7 @@ class Config {
 			$options_page['type'] = 'options_page';
 			register_graphql_field(
 				'RootQuery',
-				Config::camel_case( $page_title ),
+				$field_name,
 				[
 					'type'        => $type_name,
 					'description' => sprintf( __( '%s options', 'wp-graphql-acf' ), $options_page['page_title'] ),


### PR DESCRIPTION
In multilingual sites the option page titles are often translated like this

```php
		acf_add_options_page( array(
			'page_title' => __( 'Site settings', 'example' ),
			'menu_title' => __( 'Site settings', 'example' ),
			'menu_slug'  => 'site-settings',
			'capability' => 'manage_options',
			'redirect'   => false,
			'show_in_graphql' => true,
		) );
```

But it causes trouble for the graphql schema since the field name is currently generated from the title which means the graphql field name will vary based on the selected language which is not good.

This PR adds possibility to pass in explicit `graphql_field_name` to workaround this.


```php
		acf_add_options_page( array(
			'page_title' => __( 'Site settings', 'example' ),
			'menu_title' => __( 'Site settings', 'example' ),
			'menu_slug'  => 'site-settings',
			'capability' => 'manage_options',
			'redirect'   => false,
            // Add explicit graphql field name
            'graphql_field_name' => 'siteSettings',
			'show_in_graphql' => true,
		) );
```

It also uses the field name to generate the type name.

cc @kidunot89 