### PR TITLE
"graphql_acf_relationship_post_model" hook added.

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -504,16 +504,21 @@ class Config {
 
 						if ( ! empty( $value ) && is_array( $value ) ) {
 							foreach ( $value as $post_id ) {
+								$post_model  = null;
 								$post_object = get_post( $post_id );
 								if ( $post_object instanceof \WP_Post ) {
 									$post_model     = new Post( $post_object );
+								}
+								
+								$post_model = apply_filters( 'graphql_acf_relationship_post_model', $post_model, $post_id, $root, $acf_field );
+								
+								if ( ! empty( $post_model ) ) {
 									$relationship[] = $post_model;
 								}
 							}
 						}
 
 						return isset( $value ) ? $relationship : null;
-
 					},
 				];
 				break;


### PR DESCRIPTION
Adds a hook so a custom post type model can be provided to ACF "relationship" group type resolvers.

This is related to an issue in WooGraphQL [#253](https://github.com/wp-graphql/wp-graphql-woocommerce/issues/253).