### PR TITLE
ACF Location screen context now has "wp-graphql-acf" set to true, thi…

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -138,7 +138,7 @@ class Config {
 	 *
 	 * Get the field groups associated with the post type
 	 */
-	protected function get_acf_field_groups($args) {
+	protected function get_acf_field_groups($args = array()) {
 		add_filter('acf/location/screen', array( $this, 'add_wp_graphql_acf_to_acf_screen' ), 10, 2);
 
 		$field_groups = acf_get_field_groups($args);

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -123,6 +123,32 @@ class Config {
 	}
 
 	/**
+	 * Add attribute to the ACF screen data.
+	 *
+	 * When ACF checks the location rules we need a way to know it's from this
+	 * file.
+	 */
+	public function add_wp_graphql_acf_to_acf_screen($screen, $field_group) {
+		$screen['wp-graphql-acf'] = true;
+		return $screen;
+	}
+
+	/**
+	 * Get ACF field groups.
+	 *
+	 * Get the field groups associated with the post type
+	 */
+	protected function get_acf_field_groups($args) {
+		add_filter('acf/location/screen', array( $this, 'add_wp_graphql_acf_to_acf_screen' ), 10, 2);
+
+		$field_groups = acf_get_field_groups($args);
+
+		remove_filter('acf/location/screen', array( $this, 'add_wp_graphql_acf_to_acf_screen' ), 10);
+
+		return $field_groups;
+	}
+
+	/**
 	 * Add ACF Fields to Post Object Types.
 	 *
 	 * This gets the Post Types that are configured to show_in_graphql and iterates
@@ -150,7 +176,7 @@ class Config {
 			/**
 			 * Get the field groups associated with the post type
 			 */
-			$field_groups = acf_get_field_groups(
+			$field_groups = $this->get_acf_field_groups(
 				[
 					'post_type' => $post_type,
 				]
@@ -1145,7 +1171,7 @@ class Config {
 			/**
 			 * Get the field groups associated with the taxonomy
 			 */
-			$field_groups = acf_get_field_groups(
+			$field_groups = $this->get_acf_field_groups(
 				[
 					'taxonomy' => $taxonomy,
 				]
@@ -1204,7 +1230,7 @@ class Config {
 		/**
 		 * Get the field groups associated with the taxonomy
 		 */
-		$field_groups = acf_get_field_groups();
+		$field_groups = $this->get_acf_field_groups();
 
 		foreach ( $field_groups as $field_group ) {
 			if ( ! empty( $field_group['location'] ) && is_array( $field_group['location'] ) ) {
@@ -1265,7 +1291,7 @@ class Config {
 		/**
 		 * Get the field groups associated with the taxonomy
 		 */
-		$field_groups = acf_get_field_groups();
+		$field_groups = $this->get_acf_field_groups();
 
 		foreach ( $field_groups as $field_group ) {
 			if ( ! empty( $field_group['location'] ) && is_array( $field_group['location'] ) ) {
@@ -1327,7 +1353,7 @@ class Config {
 		/**
 		 * Get the field groups associated with the taxonomy
 		 */
-		$field_groups = acf_get_field_groups();
+		$field_groups = $this->get_acf_field_groups();
 		foreach ( $field_groups as $field_group ) {
 			if ( ! empty( $field_group['location'] ) && is_array( $field_group['location'] ) ) {
 				foreach ( $field_group['location'] as $locations ) {
@@ -1386,7 +1412,7 @@ class Config {
 		/**
 		 * Get the field groups associated with the taxonomy
 		 */
-		$field_groups = acf_get_field_groups();
+		$field_groups = $this->get_acf_field_groups();
 
 		foreach ( $field_groups as $field_group ) {
 			if ( ! empty( $field_group['location'] ) && is_array( $field_group['location'] ) ) {
@@ -1441,7 +1467,7 @@ class Config {
 		/**
 		 * Get the field groups associated with the taxonomy
 		 */
-		$field_groups = acf_get_field_groups();
+		$field_groups = $this->get_acf_field_groups();
 
 		$allowed_post_types = get_post_types( [
 			'show_ui'         => true,
@@ -1544,14 +1570,14 @@ class Config {
 		/**
 		 * Get the field groups associated with the User edit form
 		 */
-		$user_edit_field_groups = acf_get_field_groups( [
+		$user_edit_field_groups = $this->get_acf_field_groups( [
 			'user_form' => 'edit',
 		] );
 
 		/**
 		 * Get the field groups associated with the User register form
 		 */
-		$user_register_field_groups = acf_get_field_groups( [
+		$user_register_field_groups = $this->get_acf_field_groups( [
 			'user_form' => 'register',
 		] );
 
@@ -1624,7 +1650,7 @@ class Config {
 			/**
 			 * Get the field groups associated with the options page
 			 */
-			$field_groups = acf_get_field_groups(
+			$field_groups = $this->get_acf_field_groups(
 				[
 					'options_page' => $options_page['menu_slug'],
 				]


### PR DESCRIPTION
This allows for location rule validation for Field Groups to be overridden, allowing certain location rules that are not relevant to GraphQL to be ignored.

For example currently 'page template' rules will never return 'true' (thus hiding any Field Groups that have these rules set from displaying in GraphQL), we can use the ACF filter `acf/location/rule_match/$rule_param`:

    add_filter( 'acf/location/rule_match/page_template', 'ignore_acf_location_rules_for_graphql', 10, 4 );
    function ignore_acf_location_rules_for_graphql( $result, $rule, $screen, $field_group ) {
      if (isset($screen['wp-graphql-acf']) && $screen['wp-graphql-acf'] == true) return true;
    
      return $result;
    }

Probably be good to add this example to documentation but maybe someone else has changes to the format I've added.