### PR TITLE
Filtering the root-field-config before registering options-page

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1707,14 +1707,12 @@ class Config {
 			 * Register options page type to the "RootQuery"
 			 */
 			$options_page['type'] = 'options_page';
-			$field_config = apply_filters( 'wpgraphql_acf_register_root_field', [
-				[
-					'type'        => $type_name,
-					'description' => sprintf( __( '%s options', 'wp-graphql-acf' ), $options_page['page_title'] ),
-					'resolve'     => function() use ( $options_page ) {
-						return ! empty( $options_page ) ? $options_page : null;
-					}
-				]
+			$field_config = apply_filters( 'wpgraphql_acf_register_root_field_options_page', [
+				'type'        => $type_name,
+				'description' => sprintf( __( '%s options', 'wp-graphql-acf' ), $options_page['page_title'] ),
+				'resolve'     => function() use ( $options_page ) {
+					return ! empty( $options_page ) ? $options_page : null;
+				}
 			],  $field_name );
 
 			register_graphql_field( 'RootQuery', $field_name, $field_config );

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1715,7 +1715,7 @@ class Config {
 						return ! empty( $options_page ) ? $options_page : null;
 					}
 				]
-			],  $field_name);
+			],  $field_name );
 
 			register_graphql_field( 'RootQuery', $field_name, $field_config );
 

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1707,9 +1707,7 @@ class Config {
 			 * Register options page type to the "RootQuery"
 			 */
 			$options_page['type'] = 'options_page';
-			register_graphql_field(
-				'RootQuery',
-				$field_name,
+			$field_config = apply_filters( 'wpgraphql_acf_register_root_field', [
 				[
 					'type'        => $type_name,
 					'description' => sprintf( __( '%s options', 'wp-graphql-acf' ), $options_page['page_title'] ),
@@ -1717,7 +1715,9 @@ class Config {
 						return ! empty( $options_page ) ? $options_page : null;
 					}
 				]
-			);
+			],  $field_name);
+
+			register_graphql_field( 'RootQuery', $field_name, $field_config );
 
 			/**
 			 * Register option page fields to the option page type.


### PR DESCRIPTION
I am using https://github.com/BeAPI/acf-options-for-polylang to allow different values for different languages in acf-options-pages. To make this plugin work with wp-graphql-acf I need to filter the field-config on the root field, so I can add a language-argument and set the language on the resolve.

I use the filter this way:
```php
<?php
/**
 * Adding language-option for acf-options-pages
 */
add_filter('wpgraphql_acf_register_root_field_options_page', function ($config) {
    $config['args'] = [
        'language' => [
            'type' => [
                'non_null' => 'LanguageCodeFilterEnum',
            ],
        ],
    ];

    $config['resolve'] = function ($root, $args) use ($config) {
        $language = isset($args['language']) ? $args['language'] : pll_default_language('slug');
        PLL()->curlang = PLL()->model->get_language($language);

        return $config['resolve']();
    };

    return $config;
});
```

It would be awesome if you could merge this!