### PR TITLE
Add field name to flexible content

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -729,7 +729,7 @@ class Config {
 						$type = $tax_object->graphql_single_name;
 					}
 				}
-				
+
 				$is_multiple = isset($acf_field['field_type']) && in_array( $acf_field['field_type'], array('checkbox', 'multi_select'));
 
 				$field_config = [
@@ -998,6 +998,12 @@ class Config {
 											return ! empty( $flex_field_layout_name ) ? $flex_field_layout_name : null;
 										},
 									],
+									'fieldName' => [
+										'type' => 'String',
+										'resolve' => function ($source) use ($layout) {
+											return !empty($layout['name']) ? $layout['name'] : null;
+										}
+									]
 								],
 							] );
 


### PR DESCRIPTION
Add `fieldName` to flexible content. This allows the same module to be used in multiple locations. The current `fieldGroupName`, while its uniqueness is a benefit. It makes reusing the same module on different post types more difficult. Adding the slug of the ACF field allows less frontend processing whilst still knowing what is incoming and load the correct component. Giving more flexibility