### PR TITLE
Release/v0.3.5

### DIFF
--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.3.4
+ * Version:           0.3.5
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/afragen/github-updater
  *


### PR DESCRIPTION
# Release Notes

This adds support for ACF Fields to be shown with WPGraphQL Preview nodes. ACF revises meta, so when WPGraphQL returns a preview node, it uses the revised fields for ACF, where "normal" meta fields use the parent node's meta because "normal" meta is not revised. 

## GUTENBERG NOTE: 
Gutenberg (the new WordPress block editor) currently has a [bug](https://github.com/WordPress/gutenberg/issues/16006#issuecomment-657965028) that's causing meta to not be revised after posts are published, so this feature (previewing ACF meta) only works when using the Classic editor