### PR TITLE
Add support for ACF Extended Slug and Code Editor fields

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -322,6 +322,7 @@ class Config {
 			'url',
 			'password',
 			'acfe_slug',
+			'acfe_code_editor',
 			'image',
 			'file',
 			'wysiwyg',
@@ -398,6 +399,7 @@ class Config {
 			case 'oembed':
 			case 'password':
 			case 'acfe_slug':
+			case 'acfe_code_editor':
 			case 'wysiwyg':
 			case 'url':
 				// Even though Selects and Radios in ACF can _technically_ be an integer

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -315,13 +315,13 @@ class Config {
 	public static function get_supported_fields() {
 		$supported_fields = [
 			'text',
-			'acfe_slug',
 			'textarea',
 			'number',
 			'range',
 			'email',
 			'url',
 			'password',
+			'acfe_slug',
 			'image',
 			'file',
 			'wysiwyg',
@@ -394,10 +394,10 @@ class Config {
 			case 'color_picker':
 			case 'email':
 			case 'text':
-			case 'acfe_slug':
 			case 'message':
 			case 'oembed':
 			case 'password':
+			case 'acfe_slug':
 			case 'wysiwyg':
 			case 'url':
 				// Even though Selects and Radios in ACF can _technically_ be an integer

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -315,6 +315,7 @@ class Config {
 	public static function get_supported_fields() {
 		$supported_fields = [
 			'text',
+			'acfe_slug',
 			'textarea',
 			'number',
 			'range',
@@ -393,6 +394,7 @@ class Config {
 			case 'color_picker':
 			case 'email':
 			case 'text':
+			case 'acfe_slug':
 			case 'message':
 			case 'oembed':
 			case 'password':


### PR DESCRIPTION
[ACF Extended](https://www.acf-extended.com) has [10,000+ installations](https://wordpress.org/plugins/acf-extended/) and is actively being developed. Along with many other features, it adds several new field types including the "Slug" field and the "Code Editor" field.

This PR adds GraphQL support for both fields:
- Slug
- Code Editor


