### PR TITLE
Allow decimals in Range fields

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -446,7 +446,7 @@ class Config {
 				$field_config['type'] = 'String';
 				break;
 			case 'range':
-				$field_config['type'] = 'Integer';
+				$field_config['type'] = 'String';
 				break;
 			case 'number':
 				$field_config['type'] = 'Float';

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -446,7 +446,7 @@ class Config {
 				$field_config['type'] = 'String';
 				break;
 			case 'range':
-				$field_config['type'] = 'String';
+				$field_config['type'] = 'Float';
 				break;
 			case 'number':
 				$field_config['type'] = 'Float';


### PR DESCRIPTION
ACF Range fields can use decimal intervals as well as we should allow that. This fixes #163.

<img width="1272" alt="range" src="https://user-images.githubusercontent.com/1377956/93737878-a4fa1b80-fc27-11ea-8926-a8f47a0f60f7.png">

