### PR TITLE
New filter: allow non-core post types in Relationship ACF field

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -516,8 +516,17 @@ class Config {
 							foreach ( $value as $post_id ) {
 								$post_object = get_post( $post_id );
 								if ( $post_object instanceof \WP_Post ) {
-									$post_model     = new Post( $post_object );
-									$relationship[] = $post_model;
+									$post_model = new Post( $post_object );
+									
+									/**
+									 * Allow for filtering of the post model. In case a non-core defined post-type is being targeted.
+									 *
+									 * @param mixed|null  $post_model  GraphQL Model
+									 * @param mixed|null  $post_object Root ACF Field value.
+									 * @param AppContext  $context     AppContext instance.
+						 			 * @param ResolveInfo $info        ResolveInfo instance.
+									 */
+									$relationship[] = apply_filters( 'graphql_acf_relationship_model', $post_model, $post_object, $context, $info );
 								}
 							}
 						}


### PR DESCRIPTION
The current logic assumes that all post models are instances of the `Post` model. Unfortunately, when non-core post types such as WooCommerce are part of this request, the result is an internal error (see screenshot).

This filter would make it possible for extensions to properly set the correct source Type, thereby fulfilling the request. A similar filter already exists (`graphql_acf_post_object_source`) for the `post_object` field type; this new filter tries to follow the same pattern.

An example implementation would be identical to `graphql_acf_post_object_source`. See https://github.com/wp-graphql/wp-graphql-woocommerce/blob/develop/includes/class-acf-schema-filters.php#L56

**Screenshots**

Error when no filter is in place 👇🏽 
![image](https://user-images.githubusercontent.com/1371573/96822953-1d4b2c80-13e0-11eb-9834-7d2a8ae70cc9.png)


Relationship field filtering only `Product` post type 👇🏽 
![image](https://user-images.githubusercontent.com/1371573/96823109-8e8adf80-13e0-11eb-9926-022dd7e6d5b4.png)
