### PR TITLE
Replace depricated acf_get_term_post_id() function

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -233,7 +233,7 @@ class Config {
 
 			switch ( true ) {
 				case $root instanceof Term:
-					$id = acf_get_term_post_id( $root->taxonomyName, $root->term_id );
+					$id = 'term_' . $root->term_id;
 					break;
 				case $root instanceof Post:
 					$id = absint( $root->ID );
@@ -242,7 +242,7 @@ class Config {
 					$id = absint( $root->menuItemId );
 					break;
 				case $root instanceof Menu:
-					$id = acf_get_term_post_id( 'nav_menu', $root->menuId );
+					$id = 'term_' . $root->menuId;
 					break;
 				case $root instanceof User:
 					$id = 'user_' . absint( $root->userId );


### PR DESCRIPTION
The function `acf_get_term_post_id()` is depricated since ACF 5.9.2. This PR replaces it with the new recommended `'term_' . $id` string notation to prevent PHP Deprecated notices.