### PR TITLE
Bug/#251 - field groups not in graphql are preventing other groups from showing

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -200,7 +200,7 @@ class Config {
 		global $acf_options_page;
 
 		if ( ! isset( $acf_options_page ) ) {
-			return ;
+			return;
 		}
 
 		/**
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				return;
+				continue;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				return;
+				continue;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -200,7 +200,7 @@ class Config {
 		global $acf_options_page;
 
 		if ( ! isset( $acf_options_page ) ) {
-			return;
+			return ;
 		}
 
 		/**
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				continue;
+				return;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );


### PR DESCRIPTION
When the field groups are being iterated over to add to the Schema, if a field group is set to not show in graphql, there's a return statement.

This PR changes it to a continue statement.

Closes #251