### PR TITLE
Release/v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,41 @@ Setting the value of this field to "Yes" will show the field group in the WPGrap
 
 ##### Registering Fields in PHP
 
-When registering ACF Fields in PHP, `@todo`
+When registering ACF Fields in PHP, you need to add `show_in_graphql` and `graphql_field_name` when defining your field group.  See below as an example.
+
+```
+function my_acf_add_local_field_groups() {
+	
+	acf_add_local_field_group(array(
+		'key' => 'group_1',
+        'title' => 'My Group',
+        'show_in_graphql' => true,
+        'graphql_field_name' => 'myGroup',
+		'fields' => array (
+			array (
+				'key' => 'field_1',
+				'label' => 'Sub Title',
+				'name' => 'sub_title',
+				'type' => 'text',
+			)
+		),
+		'location' => array (
+			array (
+				array (
+					'param' => 'post_type',
+					'operator' => '==',
+					'value' => 'post',
+				),
+			),
+		),
+	));
+	
+}
+
+add_action('acf/init', 'my_acf_add_local_field_groups');
+```
+
+Each individual field will inherit its GraphQL name from the supplied `name` tag. In this example, `sub_title` will become `subTitle` when requested through GraphQL. If you want more granular control, you can pass `graphql_field_name` to each individual field as well.
 
 ## Supported Fields
 

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -200,7 +200,7 @@ class Config {
 		global $acf_options_page;
 
 		if ( ! isset( $acf_options_page ) ) {
-			return ;
+			return;
 		}
 
 		/**
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				return;
+				continue;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				return;
+				continue;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -200,7 +200,7 @@ class Config {
 		global $acf_options_page;
 
 		if ( ! isset( $acf_options_page ) ) {
-			return;
+			return ;
 		}
 
 		/**
@@ -1458,7 +1458,7 @@ class Config {
 			 * to graphql
 			 */
 			if ( ! $this->should_field_group_show_in_graphql( $field_group ) ) {
-				continue;
+				return;
 			}
 
 			$graphql_types = array_unique( $field_group['graphql_types'] );


### PR DESCRIPTION
# Release Notes

## Bugfix

- ([#253](https://github.com/wp-graphql/wp-graphql-acf/pull/253)): Fixes a bug ([#251](https://github.com/wp-graphql/wp-graphql-acf/pull/251)) where setting one field group to `show_in_graphql = false` was causing other field groups to also not show in the GraphQL Schema. 