### PR TITLE
#254 - add back missing type declaration for options pages.

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -270,6 +270,7 @@ class Config {
 
 				$field_name = Utils::format_field_name( $type_name );
 
+				$options_page['type'] = 'options_page';
 				$this->type_registry->register_field(
 					'RootQuery',
 					$field_name,

--- a/tests/wpunit/LocationRulesTest.php
+++ b/tests/wpunit/LocationRulesTest.php
@@ -67,6 +67,33 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function register_acf_field( $config = [] ) {
+
+		$defaults = [
+			'parent'            => $this->group_key,
+			'key'               => 'field_5d7812fd123',
+			'label'             => 'Text',
+			'name'              => 'text',
+			'type'              => 'text',
+			'instructions'      => '',
+			'required'          => 0,
+			'conditional_logic' => 0,
+			'wrapper'           => array(
+				'width' => '',
+				'class' => '',
+				'id'    => '',
+			),
+			'show_in_graphql'   => 1,
+			'default_value'     => '',
+			'placeholder'       => '',
+			'prepend'           => '',
+			'append'            => '',
+			'maxlength'         => '',
+		];
+
+		acf_add_local_field( array_merge( $defaults, $config ) );
+	}
+
 	public function testFieldGroupAssignedToPostTypeWithoutGraphqlTypesFieldShowsInSchema() {
 
 		/**
@@ -615,6 +642,18 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 			'graphql_field_name'    => 'settingsFieldsTest',
 		]);
 
+		$this->register_acf_field([
+			'parent' => 'settingsFieldsTest',
+			'name' => 'text',
+			'key' => 'settingsFieldTextField'
+		]);
+
+		$expected = 'this is a test value for the settings field';
+
+		update_field( 'settingsFieldTextField', $expected, 'option' );
+
+		update_option( 'option_text', $expected, false );
+
 		acf_add_options_page(array(
 			'page_title' 	=> 'Theme General Settings',
 			'menu_title'	=> 'Theme Settings',
@@ -649,11 +688,13 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 		  themeGeneralSettings {
 		    settingsFieldsTest {
 		      __typename
+		      text
 		    }
 		  }
 		  themeFooterSettings {
 		    settingsFieldsTest {
 		      __typename
+		      text
 		    }
 		  }
 		}
@@ -666,6 +707,7 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['themeGeneralSettings']['settingsFieldsTest']['text'] );
 
 		acf_remove_local_field_group( 'settingsFieldsTest' );
 

--- a/tests/wpunit/LocationRulesTest.php
+++ b/tests/wpunit/LocationRulesTest.php
@@ -652,8 +652,6 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 
 		update_field( 'settingsFieldTextField', $expected, 'option' );
 
-		update_option( 'option_text', $expected, false );
-
 		acf_add_options_page(array(
 			'page_title' 	=> 'Theme General Settings',
 			'menu_title'	=> 'Theme Settings',

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -25,24 +25,24 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+    'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     'name' => 'wp-graphql/wp-graphql-acf',
   ),
   'versions' => 
   array (
     'wp-graphql/wp-graphql-acf' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+      'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,24 +1,24 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+    'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     'name' => 'wp-graphql/wp-graphql-acf',
   ),
   'versions' => 
   array (
     'wp-graphql/wp-graphql-acf' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+      'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     ),
   ),
 );


### PR DESCRIPTION
The underlying Options Page type declaration was removed in v0.5.0 release. 

See: https://github.com/wp-graphql/wp-graphql-acf/pull/250/files?file-filters%5B%5D=.php&file-filters%5B%5D=.woff2&file-filters%5B%5D=.xml&file-filters%5B%5D=.yml&file-filters%5B%5D=dotfile#diff-a561f3a494f34edd4c3f2e83c25c8d4a9dc217eeeaed4385c735040450230ac0L1765

This PR adds it back and fixes null values being returned for option page values.

## Steps to Reproduce

Adding the following Options Page: 

```php
	acf_add_options_page(array(
		'page_title' 	=> 'Theme General Settings',
		'menu_title'	=> 'Theme Settings',
		'menu_slug' 	=> 'theme-general-settings',
		'capability'	=> 'edit_posts',
		'redirect'		=> false,
		'show_in_graphql' => true,
		'graphql_field_name' => 'ThemeGeneralSettings',
	));
```

Then assigning an ACF Field Group to the Options Page:

![Screen Shot 2021-04-28 at 10 26 47 AM](https://user-images.githubusercontent.com/1260765/116438973-3f4cbe00-a80c-11eb-87f1-7eb8cd8e0b8a.png)

Then populating the settings field:

![Screen Shot 2021-04-28 at 10 27 17 AM](https://user-images.githubusercontent.com/1260765/116439043-5095ca80-a80c-11eb-85cf-bccb5e997201.png)

## Before

Querying the text field in the settings returns no value

![Screen Shot 2021-04-28 at 10 25 49 AM](https://user-images.githubusercontent.com/1260765/116438856-1e846880-a80c-11eb-810f-a69e9b3f3676.png)

## After

Querying the text field in the Settings returns the expected value

![Screen Shot 2021-04-28 at 10 23 45 AM](https://user-images.githubusercontent.com/1260765/116438598-d5341900-a80b-11eb-9571-5c583c3a4d10.png)

Closes #254 