### PR TITLE
Release v0.5.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpgraphql.com/acf
 Tags: WPGraphQL, GraphQL, API, Advanced Custom Fields, ACF
 Requires at least: 5.0
 Tested up to: 5.1.1
-Stable tag: 0.5.0
+Stable tag: 0.5.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.5.0
+ * Version:           0.5.2
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.5.0';
+const WPGRAPHQL_ACF_VERSION = '0.5.2';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
# Release notes

## Bugfix

- ([#257](https://github.com/wp-graphql/wp-graphql-acf/pull/257))  Fixes regression (and adds test to prevent future regression) where ACF Options Page fields were returning null. 