### PR TITLE
Release/v0.5.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpgraphql.com/acf
 Tags: WPGraphQL, GraphQL, API, Advanced Custom Fields, ACF
 Requires at least: 5.0
 Tested up to: 5.1.1
-Stable tag: 0.5.0
+Stable tag: 0.5.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -270,6 +270,7 @@ class Config {
 
 				$field_name = Utils::format_field_name( $type_name );
 
+				$options_page['type'] = 'options_page';
 				$this->type_registry->register_field(
 					'RootQuery',
 					$field_name,

--- a/tests/wpunit/LocationRulesTest.php
+++ b/tests/wpunit/LocationRulesTest.php
@@ -67,6 +67,33 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 
 	}
 
+	public function register_acf_field( $config = [] ) {
+
+		$defaults = [
+			'parent'            => $this->group_key,
+			'key'               => 'field_5d7812fd123',
+			'label'             => 'Text',
+			'name'              => 'text',
+			'type'              => 'text',
+			'instructions'      => '',
+			'required'          => 0,
+			'conditional_logic' => 0,
+			'wrapper'           => array(
+				'width' => '',
+				'class' => '',
+				'id'    => '',
+			),
+			'show_in_graphql'   => 1,
+			'default_value'     => '',
+			'placeholder'       => '',
+			'prepend'           => '',
+			'append'            => '',
+			'maxlength'         => '',
+		];
+
+		acf_add_local_field( array_merge( $defaults, $config ) );
+	}
+
 	public function testFieldGroupAssignedToPostTypeWithoutGraphqlTypesFieldShowsInSchema() {
 
 		/**
@@ -615,6 +642,18 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 			'graphql_field_name'    => 'settingsFieldsTest',
 		]);
 
+		$this->register_acf_field([
+			'parent' => 'settingsFieldsTest',
+			'name' => 'text',
+			'key' => 'settingsFieldTextField'
+		]);
+
+		$expected = 'this is a test value for the settings field';
+
+		update_field( 'settingsFieldTextField', $expected, 'option' );
+
+		update_option( 'option_text', $expected, false );
+
 		acf_add_options_page(array(
 			'page_title' 	=> 'Theme General Settings',
 			'menu_title'	=> 'Theme Settings',
@@ -649,11 +688,13 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 		  themeGeneralSettings {
 		    settingsFieldsTest {
 		      __typename
+		      text
 		    }
 		  }
 		  themeFooterSettings {
 		    settingsFieldsTest {
 		      __typename
+		      text
 		    }
 		  }
 		}
@@ -666,6 +707,7 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 		codecept_debug( $actual );
 
 		$this->assertArrayNotHasKey( 'errors', $actual );
+		$this->assertSame( $expected, $actual['data']['themeGeneralSettings']['settingsFieldsTest']['text'] );
 
 		acf_remove_local_field_group( 'settingsFieldsTest' );
 

--- a/tests/wpunit/LocationRulesTest.php
+++ b/tests/wpunit/LocationRulesTest.php
@@ -652,8 +652,6 @@ class LocationRulesTest extends \Codeception\TestCase\WPTestCase {
 
 		update_field( 'settingsFieldTextField', $expected, 'option' );
 
-		update_option( 'option_text', $expected, false );
-
 		acf_add_options_page(array(
 			'page_title' 	=> 'Theme General Settings',
 			'menu_title'	=> 'Theme Settings',

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -25,24 +25,24 @@ class InstalledVersions
 private static $installed = array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+    'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     'name' => 'wp-graphql/wp-graphql-acf',
   ),
   'versions' => 
   array (
     'wp-graphql/wp-graphql-acf' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+      'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     ),
   ),
 );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -1,24 +1,24 @@
 <?php return array (
   'root' => 
   array (
-    'pretty_version' => 'dev-develop',
-    'version' => 'dev-develop',
+    'pretty_version' => 'dev-master',
+    'version' => 'dev-master',
     'aliases' => 
     array (
     ),
-    'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+    'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     'name' => 'wp-graphql/wp-graphql-acf',
   ),
   'versions' => 
   array (
     'wp-graphql/wp-graphql-acf' => 
     array (
-      'pretty_version' => 'dev-develop',
-      'version' => 'dev-develop',
+      'pretty_version' => 'dev-master',
+      'version' => 'dev-master',
       'aliases' => 
       array (
       ),
-      'reference' => '1bad7d6d5214448f8d27bbcd908b24d6552667cb',
+      'reference' => 'dc5e83d190211baf88978a905ff44a9122fdaff8',
     ),
   ),
 );

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.5.0
+ * Version:           0.5.2
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.5.0';
+const WPGRAPHQL_ACF_VERSION = '0.5.2';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
# Release notes

## Bugfix

- ([#257](https://github.com/wp-graphql/wp-graphql-acf/pull/257))  Fixes regression (and adds test to prevent future regression) where ACF Options Page fields were returning null. 