### PR TITLE
now checking post status

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -687,7 +687,7 @@ class Config {
 						if ( ! empty( $value ) && is_array( $value ) ) {
 							foreach ( $value as $post_id ) {
 								$post_object = get_post( $post_id );
-								if ( $post_object->status === 'publish' && $post_object instanceof \WP_Post ) {
+								if ( $post_object->post_status == 'publish' && $post_object instanceof \WP_Post ) {
 									$post_model     = new Post( $post_object );
 									$relationship[] = $post_model;
 								}

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -687,7 +687,7 @@ class Config {
 						if ( ! empty( $value ) && is_array( $value ) ) {
 							foreach ( $value as $post_id ) {
 								$post_object = get_post( $post_id );
-								if ( $post_object instanceof \WP_Post ) {
+								if ( $post_object->status === 'publish' && $post_object instanceof \WP_Post ) {
 									$post_model     = new Post( $post_object );
 									$relationship[] = $post_model;
 								}


### PR DESCRIPTION
using get_posts can be dangerous, since it returns the post regardless of wether the post is published or not. This was causing an issue when a related post was in draft or other mode. 

I added as status check to the condition that check for instance of WP_Post before the post is added to $relationship. This has fixed the issue for me.