### PR TITLE
Adds filter to register_graphql_field to enable reusing logic of existing ACF types

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -541,6 +541,14 @@ class Config {
 		}
 
 		/**
+		 * filter the acf_type variable to enable custom field types to reuse the logic of existing ones in the switch
+		 *
+		 * @param string $acf_type The original name of the ACF type for the field
+		 * @param array $config The GraphQL configuration of the field.
+		 */
+		$acf_type = apply_filters('wpgraphql_acf_register_graphql_field_overwriting_type', $acf_type, $config);
+
+		/**
 		 * filter the field config for custom field types
 		 *
 		 * @param array $field_config


### PR DESCRIPTION
Hey there!

**The problem**
So, at [Brius Media](https://brius.com.br/) we've been using wp-graphql and wp-graphql-acf for exciting new projects.

One thing we've stumbled upon is that, when we create new field types inside ACF, we had some trouble getting wp-graphql-acf to recognize them. Turns out that, inside the register_graphql_field function (in class-config), there's a switch statement that checks for certain acf_types and handles the way they're going to be shown in the API and, when we create a new ACF type, there's no way we can "stick" something in there and add our own logic.

Since what we do, in order to reuse ACF's code, is to extend their original fields and add our own logic on top, all we needed was to "trick" the switch statement into thinking that, for instance, our "foo_bar_field" was a "post_object" field. We started editing wp-graphql-acf's source code directly but, as you can imagine, that's not ideal. We also wanted to contribute since maybe this is a problem for other people.

**The solution**
We added a filter inside register_graphql_field that allows us to change the acf_type before the switch statement, thus allowing us the "reuse" the already existing logic.

This is a super simple implementation, but I'm  more than happy to assist in improving it so it can be merged and help other people.


Keep up the good work, guys!