### PR TITLE
Use date_i18n() to set correct timezone for date time fields

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -636,7 +636,7 @@ class Config {
 						$value = $this->get_acf_field_value( $root, $acf_field, true );
 
 						if ( ! empty( $value ) && ! empty( $acf_field['return_format'] ) ) {
-							$value = date( $acf_field['return_format'], strtotime( $value ) );
+							$value = date_i18n( $acf_field['return_format'], strtotime( $value ) );
 						}
 						return ! empty( $value ) ? $value : null;
 					},


### PR DESCRIPTION
## User Story

I as a user in Helsinki timezone (+3) enter a date time of **2021-10-20 10:00** to a ACF field in a WordPress installation which is configured to the same timezone.

When I view the date via graphql it is returned as `2021-10-20T10:00:00+00:00` string and when I  create a Date object from it using JavaScript I will get **2021-10-20 13:00** in the Helsinki tz, because my browser is in the Helsinki tz. I would have expected to get the same date time as I entered.


## Background

ACF does not save any timezone information to the database. See

https://www.advancedcustomfields.com/resources/date-time-picker/

--------------
![image](https://user-images.githubusercontent.com/225712/138093005-6a51af1a-72ec-47b5-a579-4056239b3beb.png)
---------------

It just copies the date time from the input directly to the database without any timezone adjustments.

So when using the `date()` it will just blindly append the utc timezone to the date without considering the installation timezone or the user's timezone. Since no timezone is saved to database, only timezone information we have is the wp installation timezone and I think we should use that.

The `date_i18n()` function will correctly use the WP timezone when formatting the date.

I believe this is a bug but this change is most likely a breaking change for those who manually have made timezone fixes in user land code.