### PR TITLE
Fix: Internal server error 500 for relationship to non-published post

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -689,12 +689,14 @@ class Config {
 								$post_object = get_post( $post_id );
 								if ( $post_object instanceof \WP_Post ) {
 									$post_model     = new Post( $post_object );
-									$relationship[] = $post_model;
+									if ( 'private' != $post_model->get_visibility() ) {
+										$relationship[] = $post_model;
+									}
 								}
 							}
 						}
 
-						return isset( $value ) ? $relationship : null;
+						return empty( $relationship ) ? null : $relationship;
 
 					},
 				];

--- a/tests/wpunit/ExplicitOptionsTest.php
+++ b/tests/wpunit/ExplicitOptionsTest.php
@@ -89,6 +89,7 @@ class ExplicitOptionsTest extends \Codeception\TestCase\WPTestCase {
 				'show_in_graphql'     => true,
 				'graphql_single_name' => 'acfCpt',
 				'graphql_plural_name' => 'acfCpts',
+				'public'              => true,
 			]
 		);
 
@@ -148,7 +149,7 @@ class ExplicitOptionsTest extends \Codeception\TestCase\WPTestCase {
 			]
 		);
 
-		$expected_text_3 = 'test value2';
+		$expected_text_3 = 'test value3';
 		update_field( 'acf_text_field', $expected_text_3, $cpt_id );
 
 		// post assert validation.

--- a/tests/wpunit/PostObjectFieldsTest.php
+++ b/tests/wpunit/PostObjectFieldsTest.php
@@ -1213,8 +1213,8 @@ class PostObjectFieldsTest extends \Codeception\TestCase\WPTestCase {
 	public function testQueryFieldOnCustomPostType() {
 
 		register_post_type( 'acf_test', [
-			'show_ui' => true,
-			'show_in_graphql' => 'true',
+			'public'              => true,
+			'show_in_graphql'     => 'true',
 			'graphql_single_name' => 'acfTest',
 			'graphql_plural_name' => 'acfTests'
 		] );


### PR DESCRIPTION
This PR fixes #300, #85, #100

If non-published post is set for relationship field, it causes 500 internal server error when users without role to see the post try to fetch the field.

In the PR #286, @matt-antone used a condition check `$post_object->status === 'publish'` to fix this issue.
Instead of that, in this PR, I used `WPGraphQL\Model\Model::get_visibility()` function to check if the user have the proper permission to read the post.
