### PR TITLE
Returning false for true_false values

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -624,7 +624,18 @@ class Config {
 				$field_config['type'] = 'Float';
 				break;
 			case 'true_false':
-				$field_config['type'] = 'Boolean';
+				$field_config = [
+					'type' => 'Boolean',
+					'resolve' => function ($root, $args, $context, $info) use ($acf_field) {
+
+						$value = $this->get_acf_field_value($root, $acf_field, true);
+						if (empty($value)) {
+							$value = false;
+						}
+
+						return $value;
+					}
+				];
 				break;
 			case 'date_picker':
 			case 'time_picker':


### PR DESCRIPTION
For `true_false` field types, the return values will always be represented as `true` or `null` depending on the value of the checkbox. This PR changes this logic so that the value will be either `true` or `false`, not `null`.