### PR TITLE
filter returned value with acf/format_value

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -459,6 +459,15 @@ class Config {
 		}
 
 		/**
+		 * Filters the returned ACF field value using acf filters
+		 *
+		 * @param mixed $value     The resolved ACF field value
+		 * @param int   $id        The ID of the object
+		 * @param array $acf_field The ACF field config
+		 */
+		$value = apply_filters('acf/format_value', $value, $id, $acf_field);
+
+		/**
 		 * Filters the returned ACF field value
 		 *
 		 * @param mixed $value     The resolved ACF field value


### PR DESCRIPTION
Run ACF `acf/filter_value` filter before running `graphql_acf_field_value` filter so users can keep existing ACF filters per field.

Original issue: https://github.com/wp-graphql/wp-graphql-acf/issues/192