### PR TITLE
Fix deprecated error in PHP > 8.0.0

### DIFF
--- a/src/location-rules.php
+++ b/src/location-rules.php
@@ -206,7 +206,7 @@ class LocationRules {
 	 *
 	 * @return bool
 	 */
-	public function check_params_for_conflicts( array $and_params = [], $param ) {
+	public function check_params_for_conflicts( array $and_params = [], string $param = '' ) {
 		switch ( $param ) {
 			case 'post_type':
 				$allowed_and_params = [


### PR DESCRIPTION
Fix Deprecated: Required parameter $param follows optional parameter $and_params