### PR TITLE
Allow for editorBlocks to get block attribute values by block name

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -378,6 +378,12 @@ class Config {
 			$id = $root['node']->ID;
 		}
 
+		if ( is_array( $root ) && isset( $root['blockName'] ) ) {
+			if ( isset( $root[ 'attrs' ][ 'data' ][ $acf_field['name'] ] ) ) {
+				$value = $root[ 'attrs' ][ 'data' ][ $acf_field['name'] ];
+			}
+		}
+
 		if ( is_array( $root ) && ! ( ! empty( $root['type'] ) && 'options_page' === $root['type'] ) ) {
 
 			if ( isset( $root[ $acf_field['key'] ] ) ) {


### PR DESCRIPTION
@jasonbahl here is the change we went through earlier today.