### PR TITLE
feat: ACF v6 support

### DIFF
--- a/src/class-acfsettings.php
+++ b/src/class-acfsettings.php
@@ -14,10 +14,14 @@ namespace WPGraphQL\ACF;
  */
 class ACF_Settings {
 
+	protected $is_acf6_or_higher = false;
+
 	/**
 	 * Initialize ACF Settings for the plugin
 	 */
 	public function init() {
+
+		$this->is_acf6_or_higher = defined( 'ACF_MAJOR_VERSION' ) && version_compare( ACF_MAJOR_VERSION, 6, '>=' );
 
 		/**
 		 * Add settings to individual fields to allow each field granular control
@@ -90,6 +94,26 @@ class ACF_Settings {
 	}
 
 	/**
+	 * Wrapper over the acf_render_field_wrap setting to support
+	 * ACF >= v6 and ACF =< v5
+	 *
+	 * @param array $config The field config to render
+	 *
+	 * @return void
+	 */
+	public function render_field_wrap( $config ) {
+
+		// The signature for acf_render_field_wrap has changed, so we
+		// treat it different for versions < 6 and versions >= 6
+		if ( $this->is_acf6_or_higher ) {
+			acf_render_field_wrap( $config, 'div', 'label', true );
+		} else {
+			acf_render_field_wrap( $config );
+		}
+
+	}
+
+	/**
 	 * Display the GraphQL Settings Metabox on the Field Group admin page
 	 *
 	 * @param $field_group_post_object
@@ -101,7 +125,7 @@ class ACF_Settings {
 		/**
 		 * Render a field in the Field Group settings to allow for a Field Group to be shown in GraphQL.
 		 */
-		acf_render_field_wrap(
+		$this->render_field_wrap(
 			[
 				'label'        => __( 'Show in GraphQL', 'acf' ),
 				'instructions' => __( 'If the field group is active, and this is set to show, the fields in this group will be available in the WPGraphQL Schema based on the respective Location rules.' ),
@@ -116,7 +140,7 @@ class ACF_Settings {
 		/**
 		 * Render a field in the Field Group settings to set the GraphQL field name for the field group.
 		 */
-		acf_render_field_wrap(
+		$this->render_field_wrap(
 			[
 				'label'        => __( 'GraphQL Field Name', 'acf' ),
 				'instructions' => __( 'The name of the field group in the GraphQL Schema. Names should not include spaces or special characters. Best practice is to use "camelCase".', 'wp-graphql-acf' ),
@@ -129,7 +153,7 @@ class ACF_Settings {
 			]
 		);
 
-		acf_render_field_wrap(
+		$this->render_field_wrap(
 			[
 				'label'        => __( 'Manually Set GraphQL Types for Field Group', 'acf' ),
 				'instructions' => __( 'By default, ACF Field groups are added to the GraphQL Schema based on the field group\'s location rules. Checking this box will let you manually control the GraphQL Types the field group should be shown on in the GraphQL Schema using the checkboxes below, and the Location Rules will no longer effect the GraphQL Types.', 'wp-graphql-acf' ),
@@ -142,7 +166,7 @@ class ACF_Settings {
 		);
 
 		$choices = Config::get_all_graphql_types();
-		acf_render_field_wrap(
+		$this->render_field_wrap(
 			[
 				'label'        => __( 'GraphQL Types to Show the Field Group On', 'wp-graphql-acf' ),
 				'instructions' => __( 'Select the Types in the WPGraphQL Schema to show the fields in this field group on', 'wp-graphql-acf' ),
@@ -164,7 +188,7 @@ class ACF_Settings {
 			if (typeof acf !== 'undefined') {
 				acf.newPostbox({
 					'id': 'wpgraphql-acf-meta-box',
-					'label': 'left'
+					'label': <?php echo $this->is_acf6_or_higher ? 'top' : "'left'"; ?>
 				});
 			}
 		</script>
@@ -217,14 +241,12 @@ class ACF_Settings {
 	public function enqueue_graphql_acf_scripts( string $screen ) {
 		global $post;
 
-		if ( $screen == 'post-new.php' || $screen == 'post.php' ) {
-			if ( 'acf-field-group' === $post->post_type ) {
-				wp_enqueue_script( 'graphql-acf', plugins_url( 'src/js/main.js', dirname( __FILE__ ) ), array(
+		if ( ( $screen === 'post-new.php' || $screen === 'post.php' ) && ( isset( $post->post_type ) && 'acf-field-group' === $post->post_type ) ) {
+				wp_enqueue_script( 'graphql-acf', plugins_url( 'src/js/main.js', __DIR__ ), array(
 					'jquery',
 					'acf-input',
 					'acf-field-group'
 				) );
-			}
 		}
 	}
 

--- a/src/class-acfsettings.php
+++ b/src/class-acfsettings.php
@@ -94,26 +94,6 @@ class ACF_Settings {
 	}
 
 	/**
-	 * Wrapper over the acf_render_field_wrap setting to support
-	 * ACF >= v6 and ACF =< v5
-	 *
-	 * @param array $config The field config to render
-	 *
-	 * @return void
-	 */
-	public function render_field_wrap( $config ) {
-
-		// The signature for acf_render_field_wrap has changed, so we
-		// treat it different for versions < 6 and versions >= 6
-		if ( $this->is_acf6_or_higher ) {
-			acf_render_field_wrap( $config, 'div', 'label', true );
-		} else {
-			acf_render_field_wrap( $config );
-		}
-
-	}
-
-	/**
 	 * Display the GraphQL Settings Metabox on the Field Group admin page
 	 *
 	 * @param $field_group_post_object
@@ -125,7 +105,7 @@ class ACF_Settings {
 		/**
 		 * Render a field in the Field Group settings to allow for a Field Group to be shown in GraphQL.
 		 */
-		$this->render_field_wrap(
+		acf_render_field_wrap(
 			[
 				'label'        => __( 'Show in GraphQL', 'acf' ),
 				'instructions' => __( 'If the field group is active, and this is set to show, the fields in this group will be available in the WPGraphQL Schema based on the respective Location rules.' ),
@@ -134,13 +114,16 @@ class ACF_Settings {
 				'prefix'       => 'acf_field_group',
 				'value'        => isset( $field_group['show_in_graphql'] ) ? (bool) $field_group['show_in_graphql'] : false,
 				'ui'           => 1,
-			]
+			],
+			'div',
+			'label',
+			true
 		);
 
 		/**
 		 * Render a field in the Field Group settings to set the GraphQL field name for the field group.
 		 */
-		$this->render_field_wrap(
+		acf_render_field_wrap(
 			[
 				'label'        => __( 'GraphQL Field Name', 'acf' ),
 				'instructions' => __( 'The name of the field group in the GraphQL Schema. Names should not include spaces or special characters. Best practice is to use "camelCase".', 'wp-graphql-acf' ),
@@ -150,10 +133,13 @@ class ACF_Settings {
 				'required'     => isset( $field_group['show_in_graphql'] ) ? (bool) $field_group['show_in_graphql'] : false,
 				'placeholder'  => ! empty( $field_group['graphql_field_name'] ) ? $field_group['graphql_field_name'] : null,
 				'value'        => ! empty( $field_group['graphql_field_name'] ) ? $field_group['graphql_field_name'] : null,
-			]
+			],
+			'div',
+			'label',
+			true
 		);
 
-		$this->render_field_wrap(
+		acf_render_field_wrap(
 			[
 				'label'        => __( 'Manually Set GraphQL Types for Field Group', 'acf' ),
 				'instructions' => __( 'By default, ACF Field groups are added to the GraphQL Schema based on the field group\'s location rules. Checking this box will let you manually control the GraphQL Types the field group should be shown on in the GraphQL Schema using the checkboxes below, and the Location Rules will no longer effect the GraphQL Types.', 'wp-graphql-acf' ),
@@ -162,11 +148,14 @@ class ACF_Settings {
 				'prefix'       => 'acf_field_group',
 				'value'        => isset( $field_group['map_graphql_types_from_location_rules'] ) ? (bool) $field_group['map_graphql_types_from_location_rules'] : false,
 				'ui'           => 1,
-			]
+			],
+			'div',
+			'label',
+			true
 		);
 
 		$choices = Config::get_all_graphql_types();
-		$this->render_field_wrap(
+		acf_render_field_wrap(
 			[
 				'label'        => __( 'GraphQL Types to Show the Field Group On', 'wp-graphql-acf' ),
 				'instructions' => __( 'Select the Types in the WPGraphQL Schema to show the fields in this field group on', 'wp-graphql-acf' ),
@@ -176,7 +165,10 @@ class ACF_Settings {
 				'value'        => ! empty( $field_group['graphql_types'] ) ? $field_group['graphql_types'] : [],
 				'toggle'       => true,
 				'choices'      => $choices,
-			]
+			],
+			'div',
+			'label',
+			true
 		);
 
 		?>

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -1340,7 +1340,7 @@ class Config {
 				$graphql_types[ $interface_name ] = '<span data-interface="'. $interface_name .'">' . $interface_name . ' Interface (' . $config['plural_label'] . ')</span>';
 				$label = '<span data-implements="'. $interface_name .'"> (' . $config['label'] . ')</span>';
 				foreach ( $possible_types as $type ) {
-					$type_label = $type['name'] . $label;
+					$type_label = $type['name'] . '&nbsp;' . $label;
 					$type_key = $type['name'];
 
 					$graphql_types[ $type_key ] = $type_label;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -201,7 +201,16 @@ $j(document).ready(function () {
 	 */
 	function setGraphqlFieldName() {
 		var graphqlFieldNameField = $j('#acf_field_group-graphql_field_name');
-		var fieldGroupTitle = $j('#titlediv #title');
+
+		// support for v6+
+		if ( $j('#title.acf-headerbar-title-field').exists() ) {
+			var fieldGroupTitle = $j('#title.acf-headerbar-title-field');
+
+		// versions of ACF < v6
+		} else {
+			var fieldGroupTitle = $j('#titlediv #title');
+		}
+
 		if ('' === graphqlFieldNameField.val()) {
 			graphqlFieldNameField.val(formatFieldName(fieldGroupTitle.val()));
 		}


### PR DESCRIPTION
This adds support for the upcoming ACF v6 release.

- add new render_field_wrap function to determine whether to use the …ACF v6+ version of acf_reder_field_wrap or the older version
- add space between Type name and label in field list
- update JS that sets the "GraphQL Field Name" based on the Field Group title