### PR TITLE
Revert "Returning false for true_false values"

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -633,18 +633,7 @@ class Config {
 				$field_config['type'] = 'Float';
 				break;
 			case 'true_false':
-				$field_config = [
-					'type' => 'Boolean',
-					'resolve' => function ($root, $args, $context, $info) use ($acf_field) {
-
-						$value = $this->get_acf_field_value($root, $acf_field, true);
-						if (empty($value)) {
-							$value = false;
-						}
-
-						return $value;
-					}
-				];
+				$field_config['type'] = 'Boolean';
 				break;
 			case 'date_picker':
 			case 'time_picker':


### PR DESCRIPTION
Reverts wp-graphql/wp-graphql-acf#304

I'm reverting this as I need to think through this better. 

If a field is not set, it should be null. 

If the field is set, and the value is true, it should be true. If isset and the value is false, it should be false. 

A non-set value should return null, because it hasn't been set yet. Returning false would be a mistake, because the value hasn't been set to false, it just hasn't been set at all yet.