### PR TITLE
Revert "filter returned value with acf/format_value"

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -459,15 +459,6 @@ class Config {
 		}
 
 		/**
-		 * Filters the returned ACF field value using acf filters
-		 *
-		 * @param mixed $value     The resolved ACF field value
-		 * @param int   $id        The ID of the object
-		 * @param array $acf_field The ACF field config
-		 */
-		$value = apply_filters('acf/format_value', $value, $id, $acf_field);
-
-		/**
 		 * Filters the returned ACF field value
 		 *
 		 * @param mixed $value     The resolved ACF field value


### PR DESCRIPTION
Reverts wp-graphql/wp-graphql-acf#309

This change is causing regressions. 

I'm not opposed to supporting something like this, but we'll need more testing.

The field type I've confirmed breaking with this in place is the gallery field. I suspect others are broken as well. 

Here's an example of the broken behavior. 

## Correct Behavior (without this filter in place)

![CleanShot 2022-09-16 at 10 40 13](https://user-images.githubusercontent.com/1260765/190688244-3ddf317f-75c7-4734-8409-2c33faa5f60a.png)

## Broken (with this filter in place)

![CleanShot 2022-09-16 at 10 40 32](https://user-images.githubusercontent.com/1260765/190688233-7c90716a-698c-4e85-afa1-6ab56038fb7d.png)