### PR TITLE
Release/v0.6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpgraphql.com/acf
 Tags: WPGraphQL, GraphQL, API, Advanced Custom Fields, ACF
 Requires at least: 5.0
 Tested up to: 5.1.1
-Stable tag: 0.6.0
+Stable tag: 0.6.1
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -459,15 +459,6 @@ class Config {
 		}
 
 		/**
-		 * Filters the returned ACF field value using acf filters
-		 *
-		 * @param mixed $value     The resolved ACF field value
-		 * @param int   $id        The ID of the object
-		 * @param array $acf_field The ACF field config
-		 */
-		$value = apply_filters('acf/format_value', $value, $id, $acf_field);
-
-		/**
 		 * Filters the returned ACF field value
 		 *
 		 * @param mixed $value     The resolved ACF field value

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.0
+ * Version:           0.6.1
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.0';
+const WPGRAPHQL_ACF_VERSION = '0.6.1';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
# Release Notes

- [#336](https://github.com/wp-graphql/wp-graphql-acf/pull/336): Reverts introduction of `acf/format_value` filter which was causing regressions.