### PR TITLE
feat: Support mutations for ACF fields

### DIFF
--- a/src/class-config.php
+++ b/src/class-config.php
@@ -602,21 +602,20 @@ class Config {
 				 *
 				 * @see: https://github.com/wp-graphql/wp-graphql-acf/issues/25
 				 */
-				$enum_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
 				if ( empty( $acf_field['multiple'] ) ) {
 					if('array' === $acf_field['return_format'] ){
-						$field_config['type'] = [ 'list_of' => $enum_type ];
+						$field_config['type'] = [ 'list_of' => $field_type ];
 						$field_config['resolve'] = function( $root ) use ( $acf_field) {
 							$value = $this->get_acf_field_value( $root, $acf_field, true);
 
 							return ! empty( $value ) && is_array( $value ) ? $value : [];
 						};
 					}else{
-						$field_config['type'] = $enum_type;
+						$field_config['type'] = $field_type;
 					}
 				} else {
-					$field_config['type']    = [ 'list_of' => $enum_type ];
+					$field_config['type']    = [ 'list_of' => $field_type ];
 					$field_config['resolve'] = function( $root ) use ( $acf_field ) {
 						$value = $this->get_acf_field_value( $root, $acf_field );
 
@@ -625,9 +624,8 @@ class Config {
 				}
 				break;
 			case 'radio':
-				$enum_type            = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
-				$field_config['type'] = $enum_type;
+				$field_type           = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_config['type'] = $field_type;
 				break;
 			case 'number':
 			case 'range':
@@ -990,79 +988,79 @@ class Config {
 				// ACF 5.8.6 added more data to Google Maps field value
 				// https://www.advancedcustomfields.com/changelog/
 				if ( \acf_version_compare(acf_get_db_version(), '>=', '5.8.6' ) ) {
-                    $fields += [
-                        'streetName' => [
+					$fields += [
+						'streetName' => [
 							'type'        => 'String',
 							'description' => __( 'The street name associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_name'] ) ? $root['street_name'] : null;
 							},
-                        ],
-                        'streetNumber' => [
+						],
+						'streetNumber' => [
 							'type'        => 'String',
 							'description' => __( 'The street number associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_number'] ) ? $root['street_number'] : null;
 							},
-                        ],
-                        'city' => [
+						],
+						'city' => [
 							'type'        => 'String',
 							'description' => __( 'The city associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['city'] ) ? $root['city'] : null;
 							},
-                        ],
-                        'state' => [
+						],
+						'state' => [
 							'type'        => 'String',
 							'description' => __( 'The state associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state'] ) ? $root['state'] : null;
 							},
-                        ],
-                        'stateShort' => [
+						],
+						'stateShort' => [
 							'type'        => 'String',
 							'description' => __( 'The state abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state_short'] ) ? $root['state_short'] : null;
 							},
-                        ],
-                        'postCode' => [
+						],
+						'postCode' => [
 							'type'        => 'String',
 							'description' => __( 'The post code associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['post_code'] ) ? $root['post_code'] : null;
 							},
-                        ],
-                        'country' => [
+						],
+						'country' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country'] ) ? $root['country'] : null;
 							},
-                        ],
-                        'countryShort' => [
+						],
+						'countryShort' => [
 							'type'        => 'String',
 							'description' => __( 'The country abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country_short'] ) ? $root['country_short'] : null;
 							},
-                        ],
-                        'placeId' => [
+						],
+						'placeId' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['place_id'] ) ? $root['place_id'] : null;
 							},
-                        ],
-                        'zoom' => [
+						],
+						'zoom' => [
 							'type'        => 'String',
 							'description' => __( 'The zoom defined with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['zoom'] ) ? $root['zoom'] : null;
 							},
-                        ],
-                    ];
-                }
+						],
+					];
+				}
 
 				$this->type_registry->register_object_type(
 					$field_type_name,
@@ -1506,12 +1504,12 @@ class Config {
 	}
 
 	public function register_choices_of_acf_fields_as_enum_type( array $acf_field ): string {
-		// If the field isn't a select or radio field, return an empty string.
-		if ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) {
-			return '';
+		// If the field isn't a select or radio field or if there are no choices available, return 'String'.
+		if ( ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) || empty( $acf_field['choices'] ) ) {
+			return 'String';
 		}
 
-		// Generate a unique name for the enum type using the field key.
+		// Generate a unique name for the enum type using the field name.
 		$enum_type_name = ucfirst( self::camel_case( $acf_field['name'] ) ) . 'Enum';
 		if ( ! $this->type_registry->has_type( $enum_type_name ) ) {
 			// Initialize an empty array to hold your enum values.

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -76,6 +76,12 @@ class Config {
 		$this->add_options_pages_to_schema();
 		$this->add_acf_fields_to_graphql_types();
 
+		/**
+		 * Add ACF Fields to GraphQL mutations
+		 */
+		$mutations_obj = new Mutations();
+		$mutations_obj->init( $type_registry, $this );
+
 		// This filter tells WPGraphQL to resolve revision meta for ACF fields from the revision's meta, instead
 		// of the parent (published post) meta.
 		add_filter( 'graphql_resolve_revision_meta_from_parent', function( $should, $object_id, $meta_key, $single ) {
@@ -167,7 +173,7 @@ class Config {
 	 * Gets the location rules
 	 * @return array
 	 */
-	protected function get_location_rules() {
+	public static function get_location_rules() {
 
 		$field_groups = acf_get_field_groups();
 		if ( empty( $field_groups ) || ! is_array( $field_groups ) ) {
@@ -296,7 +302,7 @@ class Config {
 	 *
 	 * @return bool
 	 */
-	protected function should_field_group_show_in_graphql( $field_group ) {
+	public function should_field_group_show_in_graphql( $field_group ) {
 
 		/**
 		 * By default, field groups will not be exposed to GraphQL.

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -602,19 +602,21 @@ class Config {
 				 *
 				 * @see: https://github.com/wp-graphql/wp-graphql-acf/issues/25
 				 */
+				$enum_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
 				if ( empty( $acf_field['multiple'] ) ) {
 					if('array' === $acf_field['return_format'] ){
-						$field_config['type'] = [ 'list_of' => 'String' ];
+						$field_config['type'] = [ 'list_of' => $enum_type ];
 						$field_config['resolve'] = function( $root ) use ( $acf_field) {
 							$value = $this->get_acf_field_value( $root, $acf_field, true);
 
 							return ! empty( $value ) && is_array( $value ) ? $value : [];
 						};
 					}else{
-						$field_config['type'] = 'String';
+						$field_config['type'] = $enum_type;
 					}
 				} else {
-					$field_config['type']    = [ 'list_of' => 'String' ];
+					$field_config['type']    = [ 'list_of' => $enum_type ];
 					$field_config['resolve'] = function( $root ) use ( $acf_field ) {
 						$value = $this->get_acf_field_value( $root, $acf_field );
 
@@ -623,7 +625,9 @@ class Config {
 				}
 				break;
 			case 'radio':
-				$field_config['type'] = 'String';
+				$enum_type            = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_config['type'] = $enum_type;
 				break;
 			case 'number':
 			case 'range':
@@ -1499,6 +1503,44 @@ class Config {
 			}
 		}
 
+	}
+
+	public function register_choices_of_acf_fields_as_enum_type( array $acf_field ): string {
+		// If the field isn't a select or radio field, return an empty string.
+		if ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) {
+			return '';
+		}
+
+		// Generate a unique name for the enum type using the field key.
+		$enum_type_name = ucfirst( self::camel_case( $acf_field['name'] ) ) . 'Enum';
+		if ( ! $this->type_registry->has_type( $enum_type_name ) ) {
+			// Initialize an empty array to hold your enum values.
+			$enum_values = [];
+
+			// Loop over the choices in the field and add them to the enum values array.
+			foreach ( $acf_field['choices'] as $key => $choice ) {
+				// Use the sanitize_key function to create a valid enum name from the choice key.
+				$enum_key = strtoupper( sanitize_key( $key ) );
+
+				// Add the choice to the enum values array.
+				$enum_values[ $enum_key ] = [
+					'value'       => $key,
+					'description' => $choice,
+				];
+			}
+
+			// Register enum type.
+			$this->type_registry->register_enum_type(
+				$enum_type_name,
+				[
+					'description' => $acf_field['label'],
+					'values'      => $enum_values,
+				]
+			);
+		}
+
+		// Return the enum type name.
+		return $enum_type_name;
 	}
 
 }

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -988,79 +988,79 @@ class Config {
 				// ACF 5.8.6 added more data to Google Maps field value
 				// https://www.advancedcustomfields.com/changelog/
 				if ( \acf_version_compare(acf_get_db_version(), '>=', '5.8.6' ) ) {
-					$fields += [
-						'streetName' => [
+                    $fields += [
+                        'streetName' => [
 							'type'        => 'String',
 							'description' => __( 'The street name associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_name'] ) ? $root['street_name'] : null;
 							},
-						],
-						'streetNumber' => [
+                        ],
+                        'streetNumber' => [
 							'type'        => 'String',
 							'description' => __( 'The street number associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['street_number'] ) ? $root['street_number'] : null;
 							},
-						],
-						'city' => [
+                        ],
+                        'city' => [
 							'type'        => 'String',
 							'description' => __( 'The city associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['city'] ) ? $root['city'] : null;
 							},
-						],
-						'state' => [
+                        ],
+                        'state' => [
 							'type'        => 'String',
 							'description' => __( 'The state associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state'] ) ? $root['state'] : null;
 							},
-						],
-						'stateShort' => [
+                        ],
+                        'stateShort' => [
 							'type'        => 'String',
 							'description' => __( 'The state abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['state_short'] ) ? $root['state_short'] : null;
 							},
-						],
-						'postCode' => [
+                        ],
+                        'postCode' => [
 							'type'        => 'String',
 							'description' => __( 'The post code associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['post_code'] ) ? $root['post_code'] : null;
 							},
-						],
-						'country' => [
+                        ],
+                        'country' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country'] ) ? $root['country'] : null;
 							},
-						],
-						'countryShort' => [
+                        ],
+                        'countryShort' => [
 							'type'        => 'String',
 							'description' => __( 'The country abbreviation associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['country_short'] ) ? $root['country_short'] : null;
 							},
-						],
-						'placeId' => [
+                        ],
+                        'placeId' => [
 							'type'        => 'String',
 							'description' => __( 'The country associated with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['place_id'] ) ? $root['place_id'] : null;
 							},
-						],
-						'zoom' => [
+                        ],
+                        'zoom' => [
 							'type'        => 'String',
 							'description' => __( 'The zoom defined with the map', 'wp-graphql-acf' ),
 							'resolve'     => function( $root ) {
 								return isset( $root['zoom'] ) ? $root['zoom'] : null;
 							},
-						],
-					];
-				}
+                        ],
+                    ];
+                }
 
 				$this->type_registry->register_object_type(
 					$field_type_name,

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -692,7 +692,11 @@ class Config {
 						$relationship = [];
 						$value        = $this->get_acf_field_value( $root, $acf_field );
 
-						if ( ! empty( $value ) && is_array( $value ) ) {
+						if ( ! empty( $value ) ) {
+							// It sometimes saved as single id like in case of WPML sync acf field to translations posts
+							if ( ! is_array( $value ) ) {
+								$value = [ $value ];
+							}
 							foreach ( $value as $post_id ) {
 								$post_object = get_post( $post_id );
 								if ( $post_object instanceof \WP_Post ) {

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -18,6 +18,7 @@ use WPGraphQL\Model\Post;
 use WPGraphQL\Model\Term;
 use WPGraphQL\Model\User;
 use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Type\WPEnumType;
 use WPGraphQL\Utils\Utils;
 
 /**
@@ -366,16 +367,6 @@ class Config {
 		return $str;
 	}
 
-	public static function convert_to_snake_case( string $str ): string {
-		// non-alpha and non-numeric characters become spaces.
-		$str = preg_replace( '/[^a-z0-9]+/i', ' ', $str );
-		$str = trim( $str );
-		// Lowercase the string.
-		$str = strtolower( $str );
-		// Replace spaces.
-		return str_replace( ' ', '_', $str );
-	}
-
 	/**
 	 * Undocumented function
 	 *
@@ -612,7 +603,7 @@ class Config {
 				 *
 				 * @see: https://github.com/wp-graphql/wp-graphql-acf/issues/25
 				 */
-				$field_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_type = $this->register_choices_of_acf_fields_as_enum_type( $acf_field, $type_name );
 				if ( empty( $acf_field['multiple'] ) ) {
 					if('array' === $acf_field['return_format'] ){
 						$field_config['type'] = [ 'list_of' => $field_type ];
@@ -634,7 +625,7 @@ class Config {
 				}
 				break;
 			case 'radio':
-				$field_type           = $this->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_type           = $this->register_choices_of_acf_fields_as_enum_type( $acf_field, $type_name );
 				$field_config['type'] = $field_type;
 				break;
 			case 'number':
@@ -1517,28 +1508,62 @@ class Config {
 
 	}
 
-	public function register_choices_of_acf_fields_as_enum_type( array $acf_field ): string {
+	public function register_choices_of_acf_fields_as_enum_type( array $acf_field, string $parent_type_name = '' ): string {
 		// If the field isn't a select or radio field or if there are no choices available, return 'String'.
 		if ( ( 'select' !== $acf_field['type'] && 'radio' !== $acf_field['type'] ) || empty( $acf_field['choices'] ) ) {
 			return 'String';
 		}
 
-		// Generate a unique name for the enum type using the field name.
+		// Generate a unique name for the enum type using the parent type name and the field name,
+		// mirroring how object type names accumulate their full field ancestry. Without the parent
+		// prefix, two select/radio fields sharing a name anywhere in the schema would collide on the
+		// same enum type name (first registration wins), including WPGraphQL core enums like TaxonomyEnum.
 		$enum_type_name = ucfirst( self::camel_case( $acf_field['name'] ) ) . 'Enum';
+		if ( '' !== $parent_type_name ) {
+			$enum_type_name = $parent_type_name . '_' . $enum_type_name;
+		}
 		if ( ! $this->type_registry->has_type( $enum_type_name ) ) {
 			// Initialize an empty array to hold your enum values.
 			$enum_values = [];
 
 			// Loop over the choices in the field and add them to the enum values array.
 			foreach ( $acf_field['choices'] as $key => $choice ) {
-				// Use the sanitize_key function to create a valid enum name from the choice key.
-				$enum_key = strtoupper( self::convert_to_snake_case( $key ) );
+				// Skip an empty choice key (e.g. an explicit "none" option). It has no valid
+				// enum value name, and an empty saved value already resolves to null anyway.
+				// Note the strict comparison so a legitimate "0" key is not treated as empty.
+				if ( '' === trim( (string) $key ) ) {
+					continue;
+				}
+
+				// Delegate enum value-name sanitization to WPGraphQL core's canonical helper.
+				// It handles invalid characters, a leading digit, and reserved leading
+				// underscores the same way core builds its own enums, so an odd choice key
+				// can never produce a spec-invalid name that makes the whole schema unloadable.
+				$enum_key = WPEnumType::get_safe_name( (string) $key );
+
+				// Two distinct choice keys can sanitize to the same enum value name
+				// (e.g. "red-color" and "red_color" both become RED_COLOR). Append a numeric
+				// suffix instead of letting the later choice silently overwrite the earlier one,
+				// so every choice stays selectable and round-trips to its own stored value.
+				if ( isset( $enum_values[ $enum_key ] ) ) {
+					$suffix = 2;
+					while ( isset( $enum_values[ $enum_key . '_' . $suffix ] ) ) {
+						$suffix++;
+					}
+					$enum_key .= '_' . $suffix;
+				}
 
 				// Add the choice to the enum values array.
 				$enum_values[ $enum_key ] = [
 					'value'       => $key,
 					'description' => $choice,
 				];
+			}
+
+			// An enum type with no values is invalid in GraphQL (e.g. the field's only choice
+			// had an empty key). Fall back to a plain String in that case.
+			if ( empty( $enum_values ) ) {
+				return 'String';
 			}
 
 			// Register enum type.

--- a/src/class-config.php
+++ b/src/class-config.php
@@ -366,6 +366,16 @@ class Config {
 		return $str;
 	}
 
+	public static function convert_to_snake_case( string $str ): string {
+		// non-alpha and non-numeric characters become spaces.
+		$str = preg_replace( '/[^a-z0-9]+/i', ' ', $str );
+		$str = trim( $str );
+		// Lowercase the string.
+		$str = strtolower( $str );
+		// Replace spaces.
+		return str_replace( ' ', '_', $str );
+	}
+
 	/**
 	 * Undocumented function
 	 *
@@ -1522,7 +1532,7 @@ class Config {
 			// Loop over the choices in the field and add them to the enum values array.
 			foreach ( $acf_field['choices'] as $key => $choice ) {
 				// Use the sanitize_key function to create a valid enum name from the choice key.
-				$enum_key = strtoupper( sanitize_key( $key ) );
+				$enum_key = strtoupper( self::convert_to_snake_case( $key ) );
 
 				// Add the choice to the enum values array.
 				$enum_values[ $enum_key ] = [

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -102,6 +102,7 @@ class Mutations
 
 	private function save_registered_fields_data( int $object_id, string $object_type, array $fields_data, array $registered_fields ): void
 	{
+		$acf_changed = false;
 		foreach ( $fields_data as $key => $value ) {
 			if ( ! empty( $registered_fields[$key] ) ) {
 				if ( ! empty( $registered_fields[$key]['sub_fields_config'] ) ) {
@@ -116,7 +117,15 @@ class Mutations
 				else {
 					$this->update_acf_field_value( $object_id, $object_type, $value, $registered_fields[$key] );
 				}
+				$acf_changed = true;
 			}
+		}
+
+		// We need this to let the revision code of ACF to work correctly.
+		// advanced-custom-fields-pro/includes/revisions.php
+		if ( $acf_changed && $object_type === self::POST_OBJECT_TYPE ) {
+			$_POST['_acf_changed'] = 1;
+			do_action( 'acf/save_post', $object_id );
 		}
 	}
 

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -318,11 +318,9 @@ class Mutations
 			case 'textarea':
 				$field_config['type'] = 'String';
 				break;
-
 			case 'radio':
-				$enum_type            = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
-				$field_config['type'] = $enum_type;
+				$field_type           = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_config['type'] = $field_type;
 				break;
 			case 'select':
 
@@ -331,12 +329,11 @@ class Mutations
 				 * the field will accept a string, but if it is configured to allow
 				 * multiple values it will accept a list of strings
 				 */
-				$enum_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
-				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
 				if ( empty( $acf_field['multiple'] ) ) {
-					$field_config['type'] = $enum_type;
+					$field_config['type'] = $field_type;
 				} else {
-					$field_config['type'] = [ 'list_of' => $enum_type ];
+					$field_config['type'] = [ 'list_of' => $field_type ];
 				}
 				break;
 			case 'number':

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -316,8 +316,13 @@ class Mutations
 			case 'wysiwyg':
 			case 'url':
 			case 'textarea':
-			case 'radio':
 				$field_config['type'] = 'String';
+				break;
+
+			case 'radio':
+				$enum_type            = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type            = ! empty( $enum_type ) ? $enum_type : 'String';
+				$field_config['type'] = $enum_type;
 				break;
 			case 'select':
 
@@ -326,10 +331,12 @@ class Mutations
 				 * the field will accept a string, but if it is configured to allow
 				 * multiple values it will accept a list of strings
 				 */
+				$enum_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$enum_type = ! empty( $enum_type ) ? $enum_type : 'String';
 				if ( empty( $acf_field['multiple'] ) ) {
-					$field_config['type'] = 'String';
+					$field_config['type'] = $enum_type;
 				} else {
-					$field_config['type'] = [ 'list_of' => 'String' ];
+					$field_config['type'] = [ 'list_of' => $enum_type ];
 				}
 				break;
 			case 'number':

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -1,0 +1,579 @@
+<?php
+
+namespace WPGraphQL\ACF;
+
+use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Utils\Utils;
+
+class Mutations
+{
+
+	const POST_OBJECT_TYPE = 'Post';
+	const TERM_OBJECT_TYPE = 'Term';
+
+	/**
+	 * @var TypeRegistry
+	 */
+	private $type_registry;
+
+	/**
+	 * @var Config
+	 */
+	private $config;
+
+	/**
+	 * Stores the location rules for back compat
+	 * @var array
+	 */
+	private $location_rules = [];
+
+	/**
+	 * Stores the ACF field groups
+	 * @var array
+	 */
+	private $field_groups = [];
+
+	/**
+	 * Stores the registered ACF fields
+	 * @var array
+	 */
+	private $registered_fields = [];
+
+    public function init( TypeRegistry $type_registry, Config $config ): void
+    {
+	    $this->type_registry = $type_registry;
+	    $this->config = $config;
+
+	    /**
+	     * Get all the field groups
+	     */
+	    $this->field_groups = acf_get_field_groups();
+
+	    /**
+	     * If there are no acf field groups, bail
+	     */
+	    if ( empty( $this->field_groups ) || ! is_array( $this->field_groups ) ) {
+		    return;
+	    }
+
+	    /**
+	     * Gets the location rules for those fields that do not have "graphql_type".
+	     *
+	     * This allows for ACF Field Groups that were registered before the "graphql_types" ( backward compatibility )
+	     * or registered from code can still work with the old GraphQL Schema rules that mapped
+	     * from the ACF Location rules.
+	     */
+	    $this->location_rules = Config::get_location_rules();
+
+	    /**
+	     * Add ACF Fields to GraphQL Mutations
+	     */
+	    $this->add_acf_fields_to_graphql_types();
+
+	    add_action( 'graphql_post_object_mutation_update_additional_data', function ( int $post_id, array $input ) {
+			$this->save_registered_fields_data( $post_id, self::POST_OBJECT_TYPE, $input, $this->registered_fields );
+	    }, 10, 2 );
+
+		add_filter( 'graphql_term_object_insert_term_args', function ( array $insert_args, array $input ) {
+			self::add_action_once( 'graphql_insert_term', function ( int $term_id ) use ( $input ) {
+			    $this->save_registered_fields_data( $term_id, self::TERM_OBJECT_TYPE, $input, $this->registered_fields );
+		    } );
+			self::add_action_once( 'graphql_update_term', function ( int $term_id ) use ( $input ) {
+				$this->save_registered_fields_data( $term_id, self::TERM_OBJECT_TYPE, $input, $this->registered_fields );
+			} );
+
+			return $insert_args;
+		}, 10, 2 );
+    }
+
+	private function save_registered_fields_data( int $object_id, string $object_type, array $fields_data, array $registered_fields ): void
+	{
+		foreach ( $fields_data as $key => $value ) {
+			if ( ! empty( $registered_fields[$key] ) ) {
+				if ( ! empty( $registered_fields[$key]['sub_fields_config'] ) ) {
+					$this->save_registered_fields_data( $object_id, $object_type, $value, $registered_fields[$key]['sub_fields_config'] );
+				}
+				else if (
+					! empty( $registered_fields[$key]['mutate'] )
+					&& is_callable( $registered_fields[$key]['mutate'] )
+				) {
+					call_user_func_array( $registered_fields[$key]['mutate'], [ $object_id, $object_type, $value, $registered_fields[$key] ] );
+				}
+				else {
+					$this->update_acf_field_value( $object_id, $object_type, $value, $registered_fields[$key] );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Given a field group array, this adds the fields to the specified Type in the Schema
+	 *
+	 * @param array  $field_group The group to add to the Schema.
+	 * @param bool   $layout      Whether or not these fields are part of a Flex Content layout.
+	 *
+	 * @return array|null
+	 */
+	private function add_field_group_fields( array $field_group, bool $layout = false ) {
+
+		/**
+		 * If the field group has the show_in_graphql setting configured, respect it's setting
+		 * otherwise default to true (for nested fields)
+		 */
+		$field_group['show_in_graphql'] = isset( $field_group['show_in_graphql'] ) ? (boolean) $field_group['show_in_graphql'] : true;
+
+		/**
+		 * Determine if the field group should be exposed
+		 * to graphql
+		 */
+		if ( ! $this->config->should_field_group_show_in_graphql( $field_group ) ) {
+			return null;
+		}
+
+		/**
+		 * Get the fields in the group.
+		 */
+		$acf_fields = ! empty( $field_group['sub_fields'] ) || $layout ? $field_group['sub_fields'] : acf_get_fields( $field_group );
+
+		/**
+		 * If there are no fields, bail
+		 */
+		if ( empty( $acf_fields ) || ! is_array( $acf_fields ) ) {
+			return null;
+		}
+
+		/**
+		 * Stores field keys to prevent duplicate field registration for cloned fields
+		 */
+		$processed_keys = [];
+
+		$registered_fields = [];
+		/**
+		 * Loop over the fields and register them to the Schema
+		 */
+		foreach ( $acf_fields as $acf_field ) {
+			if ( in_array( $acf_field['key'], $processed_keys, true ) ) {
+				continue;
+			} else {
+				$processed_keys[] = $acf_field['key'];
+			}
+
+			/**
+			 * Setup data for register_graphql_field
+			 */
+			$explicit_name   = ! empty( $acf_field['graphql_field_name'] ) ? $acf_field['graphql_field_name'] : null;
+			$name            = empty( $explicit_name ) && ! empty( $acf_field['name'] ) ? Config::camel_case( $acf_field['name'] ) : $explicit_name;
+			$show_in_graphql = isset( $acf_field['show_in_graphql'] ) ? (bool) $acf_field['show_in_graphql'] : true;
+			$description     = isset( $acf_field['instructions'] ) ? $acf_field['instructions'] : __( 'ACF Field added to the Schema by WPGraphQL ACF' );
+
+			/**
+			 * If the field is missing a name or a type,
+			 * we can't add it to the Schema.
+			 */
+			if (
+				empty( $name ) ||
+				true != $show_in_graphql
+			) {
+
+				/**
+				 * Uncomment line below to determine what fields are not going to be output
+				 * in the Schema.
+				 */
+				continue;
+			}
+
+			$config = [
+				'name'            => $name,
+				'description'     => $description,
+				'acf_field'       => $acf_field,
+				'acf_field_group' => $field_group,
+			];
+
+			$field_config = $this->register_graphql_field( $name, $config );
+			if ( ! empty( $field_config ) ) {
+				$registered_fields[$name] = $field_config;
+			}
+
+		}
+
+		return $registered_fields;
+	}
+
+	private function get_field_key( $acf_field ) {
+		/**
+		 * Check if cloned field and retrieve the key accordingly.
+		 */
+		if ( ! empty( $acf_field['_clone'] ) ) {
+			$key = $acf_field['__key'];
+		} else {
+			$key = $acf_field['key'];
+		}
+
+		return $key;
+	}
+
+	private function maybe_filter_value( $field_config, $value ) {
+		$original_value = $value;
+		$filtered_value = $value;
+
+		if (
+			! empty( $field_config['filter_value'] )
+			&& is_callable( $field_config['filter_value'] )
+		) {
+			$filtered_value = call_user_func_array( $field_config['filter_value'], [ $filtered_value ] );
+		}
+
+		$acf_type 	= $field_config['acf_field']['type'];
+		$field_name = $field_config['name'];
+
+		return apply_filters( 'wpgraphql_acf_filter_mutation_field_value', $filtered_value, $acf_type, $original_value, $field_name, $field_config );
+	}
+
+	private function update_acf_field_value( int $object_id, string $object_type, $value, array $field_config, bool $use_add_row = false ) {
+
+		switch ( $object_type ) {
+			case self::TERM_OBJECT_TYPE:
+				$object_id = 'term_' . $object_id;
+				break;
+			case self::POST_OBJECT_TYPE:
+				// do nothing in this case
+				break;
+//			case $root instanceof MenuItem:
+//				$id = absint( $root->menuItemId );
+//				break;
+//			case $root instanceof Menu:
+//				$id = 'term_' . $root->menuId;
+//				break;
+//			case $root instanceof User:
+//				$id = 'user_' . absint( $root->userId );
+//				break;
+//			case $root instanceof Comment:
+//				$id = 'comment_' . absint( $root->databaseId );
+//				break;
+//			case is_array( $root ) && ! empty( $root['type'] ) && 'options_page' === $root['type']:
+//				$id = $root['post_id'];
+//				break;
+			default:
+				$object_id = null;
+				break;
+		}
+
+		if ( empty( $object_id ) ) {
+			return null;
+		}
+
+		$acf_field = $field_config['acf_field'];
+		$key = $this->get_field_key( $acf_field );
+
+		$value = $this->maybe_filter_value( $field_config, $value );
+
+		if ( $value !== null ) {
+			if ( $use_add_row ) {
+				add_row( $key, $value, $object_id );
+			}
+			else {
+				update_field( $key, $value, $object_id );
+			}
+		}
+	}
+
+	private function prepare_input_type_name( string $acf_field_name ): string {
+		$field_type_name = 'ACF_' . ucfirst( Config::camel_case( $acf_field_name ) ) . 'Input';
+
+		$counter = 1;
+		while ( null !== $this->type_registry->get_type( $field_type_name ) ) {
+			$field_type_name .= "_{$counter}";
+			$counter++;
+		}
+
+		return $field_type_name;
+	}
+
+	/**
+	 * Undocumented function
+	 *
+	 * @param string $field_name The name of the field to add to the GraphQL Type.
+	 * @param array $config The GraphQL configuration of the field.
+	 *
+	 * @return array|null
+	 */
+	private function register_graphql_field( string $field_name, array $config ) {
+		$acf_field = isset( $config['acf_field'] ) ? $config['acf_field'] : null;
+		$acf_type  = isset( $acf_field['type'] ) ? $acf_field['type'] : null;
+
+		if ( empty( $acf_type ) ) {
+			return null;
+		}
+
+		$field_config = [
+			'type'    => null,
+		];
+
+		switch ( $acf_type ) {
+			case 'button_group':
+			case 'color_picker':
+			case 'email':
+			case 'text':
+			case 'message':
+			case 'oembed':
+			case 'password':
+			case 'wysiwyg':
+			case 'url':
+			case 'textarea':
+			case 'radio':
+				$field_config['type'] = 'String';
+				break;
+			case 'select':
+
+				/**
+				 * If the select field is configured to not allow multiple values
+				 * the field will accept a string, but if it is configured to allow
+				 * multiple values it will accept a list of strings
+				 */
+				if ( empty( $acf_field['multiple'] ) ) {
+					$field_config['type'] = 'String';
+				} else {
+					$field_config['type'] = [ 'list_of' => 'String' ];
+				}
+				break;
+			case 'number':
+			case 'range':
+				$field_config['type'] = 'Float';
+				break;
+			case 'true_false':
+				$field_config['type'] = 'Boolean';
+				break;
+			case 'date_picker':
+			case 'time_picker':
+			case 'date_time_picker':
+				$field_config = [
+					'type'    => 'String',
+					'filter_value' => function( $value ) use ( $acf_type ) {
+						$timestamp = strtotime( $value );
+						if ( $timestamp !== false ) {
+							switch ( $acf_type ) {
+								case 'time_picker':
+									$value = gmdate( 'H:i:s', $timestamp );
+									break;
+								case 'date_picker':
+									$value = gmdate( 'Y-m-d', $timestamp );
+									break;
+								default:// 'date_time_picker'
+									$value = gmdate( 'Y-m-d H:i:s', $timestamp );
+									break;
+							}
+
+							return $value;
+						}
+						return null;
+					}
+				];
+				break;
+			case 'relationship':
+				$field_config['type'] = [ 'list_of' => 'ID' ];
+				break;
+			case 'image':
+			case 'file':
+				$field_config = [
+					'type'    => 'String',
+					'filter_value' => function( $value ) {
+						$attachment_url = $value;
+						if ( ! empty( $attachment_url ) ) {
+							$attach_id = attachment_url_to_postid( $attachment_url );
+
+							if ( ! empty( $attach_id ) ) {
+								return $attach_id;
+							}
+						}
+						return null;
+					},
+				];
+				break;
+			case 'checkbox':
+				$field_config['type'] = [ 'list_of' => 'String' ];
+				break;
+			case 'taxonomy':
+				$is_multiple = isset( $acf_field['field_type'] ) && in_array( $acf_field['field_type'], [ 'checkbox', 'multi_select' ] );
+
+				$field_config['type'] = $is_multiple ? [ 'list_of' => 'ID' ] : 'ID';
+				break;
+			// Accordions are not represented in the GraphQL Schema.
+			case 'accordion':
+				$field_config = null;
+				break;
+			case 'group':
+
+				$field_type_name = $this->prepare_input_type_name( $acf_field['name'] );
+
+				$sub_fields_config = $this->add_field_group_fields( $acf_field );
+
+				if ( ! empty( $sub_fields_config ) ) {
+					$this->type_registry->register_input_type(
+						$field_type_name,
+						[
+							'description' => __( 'Field Group', 'wp-graphql-acf' ),
+							'fields'      => $sub_fields_config,
+						]
+					);
+
+					$field_config = [
+						'type' => $field_type_name,
+						'sub_fields_config' => $sub_fields_config,
+					];
+				}
+				break;
+			case 'repeater':
+
+				$field_type_name = $this->prepare_input_type_name( $acf_field['name'] );
+
+				$sub_fields_config = $this->add_field_group_fields( $acf_field );
+
+				if ( ! empty( $sub_fields_config ) ) {
+					$this->type_registry->register_input_type(
+						$field_type_name,
+						[
+							'description' => __( 'Field Group', 'wp-graphql-acf' ),
+							'fields'      => $sub_fields_config,
+						]
+					);
+
+					$field_config = [
+						'type' => [ 'list_of' => $field_type_name ],
+						'repeater_sub_fields_config' => $sub_fields_config,
+						'mutate' => function( $object_id, $object_type, $rows, $field_config ) use ( $sub_fields_config ) {
+							if ( ! empty( $rows ) && is_array( $rows ) ) {
+								foreach ( $rows as $row ) {
+									$row_value = [];
+									foreach ( $row as $sub_field_key => $sub_field_value ) {
+										$sub_field_config = $sub_fields_config[$sub_field_key];
+										if ( ! empty( $sub_field_config ) ) {
+											$sub_field_value = $this->maybe_filter_value( $sub_field_config, $sub_field_value );
+
+											if ( $sub_field_value !== null ) {
+												$acf_key = $this->get_field_key( $sub_field_config['acf_field'] );
+												$row_value[$acf_key] = $sub_field_value;
+											}
+										}
+									}
+
+									if ( ! empty( $row_value ) ) {
+										$this->update_acf_field_value( $object_id, $object_type, $row_value, $field_config, true );
+									}
+								}
+							}
+						},
+					];
+				}
+				break;
+//			case 'page_link':
+//			case 'post_object':
+//			case 'link':
+//			case 'gallery':
+//			case 'user':
+//			case 'google_map':
+//			case 'flexible_content':
+//				break;
+			default:
+				break;
+		}
+
+		if ( empty( $field_config ) || empty( $field_config['type'] ) ) {
+			return null;
+		}
+
+		return array_merge( $config, $field_config );
+	}
+
+	/**
+	 * Adds acf field groups to GraphQL Mutations.
+	 */
+	private function add_acf_fields_to_graphql_types() {
+		/**
+		 * Loop over all the field groups
+		 */
+		foreach ( $this->field_groups as $field_group ) {
+
+			$field_group_name = isset( $field_group['graphql_field_name'] ) ? $field_group['graphql_field_name'] : $field_group['title'];
+			$field_group_name = Utils::format_field_name( $field_group_name );
+
+			$manually_set_graphql_types = isset( $field_group['map_graphql_types_from_location_rules'] ) ? (bool) $field_group['map_graphql_types_from_location_rules'] : false;
+
+			if ( false === $manually_set_graphql_types ) {
+				if ( ! isset( $field_group['graphql_types'] ) || empty( $field_group['graphql_types'] ) ) {
+					$field_group['graphql_types'] = [];
+					if ( isset( $this->location_rules[ $field_group_name ] ) ) {
+						$field_group['graphql_types'] = $this->location_rules[ $field_group_name ];
+					}
+				}
+			}
+
+			if ( ! is_array( $field_group['graphql_types'] ) || empty( $field_group['graphql_types'] ) ) {
+				continue;
+			}
+
+			/**
+			 * Determine if the field group should be exposed
+			 * to graphql
+			 */
+			if ( ! $this->config->should_field_group_show_in_graphql( $field_group ) ) {
+				continue;
+			}
+
+			$graphql_types = array_unique( $field_group['graphql_types'] );
+			$graphql_types = array_filter( $graphql_types );
+
+			/**
+			 * Prepare default info
+			 */
+			$field_name = isset( $field_group['graphql_field_name'] ) ? $field_group['graphql_field_name'] : Config::camel_case( $field_group['title'] );
+			$field_group['type'] = 'group';
+			$field_group['name'] = $field_name;
+			$config              = [
+				'name'            => $field_name,
+				'acf_field'       => $field_group,
+				'acf_field_group' => null,
+			];
+
+			$qualifier =  sprintf( __( 'Added to the GraphQL Schema because the ACF Field Group "%1$s" was set to Show in GraphQL.', 'wp-graphql-acf' ), $field_group['title'] );
+			$config['description'] = $field_group['description'] ? $field_group['description'] . ' | ' . $qualifier : $qualifier;
+
+			$field_config = $this->register_graphql_field( $field_name, $config );
+			if ( ! empty( $field_config ) ) {
+				/**
+				 * Loop over the GraphQL types for this field group on
+				 */
+				foreach ( $graphql_types as $graphql_type ) {
+					$this->type_registry->register_field( "Create{$graphql_type}Input", $field_name, $field_config );
+					$this->type_registry->register_field( "Update{$graphql_type}Input", $field_name, $field_config );
+				}
+
+				$this->registered_fields[$field_name] = $field_config;
+			}
+		}
+	}
+
+	/**
+	 * Register an action to run exactly one time.
+	 *
+	 * The arguments match that of add_action(), but this function will also register a second
+	 * callback designed to remove the first immediately after it runs.
+	 *
+	 * @param string   $hook_name       The name of the action to add the callback to.
+	 * @param callable $callback        The callback to be run when the action is called.
+	 * @param int      $priority        Optional. Used to specify the order in which the functions
+	 *                                  associated with a particular action are executed.
+	 *                                  Lower numbers correspond with earlier execution,
+	 *                                  and functions with the same priority are executed
+	 *                                  in the order in which they were added to the action. Default 10.
+	 * @param int      $accepted_args   Optional. The number of arguments the function accepts. Default 1.
+	 * @return bool Like add_action(), this function always returns true.
+	 */
+	public static function add_action_once( string $hook_name, callable $callback, int $priority = 10, int $accepted_args = 1 ): bool {
+		$singular = function () use ( $hook_name, $callback, $priority, $accepted_args, &$singular ) {
+			remove_action( $hook_name, $singular, $priority );
+			call_user_func_array( $callback, func_get_args() );
+		};
+
+		return add_action( $hook_name, $singular, $priority, $accepted_args );
+	}
+}

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -105,6 +105,11 @@ class Mutations
 		$acf_changed = false;
 		foreach ( $fields_data as $key => $value ) {
 			if ( ! empty( $registered_fields[$key] ) ) {
+				// Control flags (e.g. a repeater's "<field>Append") are handled alongside
+				// their field, not saved as data of their own.
+				if ( ! empty( $registered_fields[$key]['is_append_flag'] ) ) {
+					continue;
+				}
 				if ( ! empty( $registered_fields[$key]['sub_fields_config'] ) ) {
 					$this->save_registered_fields_data( $object_id, $object_type, $value, $registered_fields[$key]['sub_fields_config'] );
 				}
@@ -112,7 +117,13 @@ class Mutations
 					! empty( $registered_fields[$key]['mutate'] )
 					&& is_callable( $registered_fields[$key]['mutate'] )
 				) {
-					call_user_func_array( $registered_fields[$key]['mutate'], [ $object_id, $object_type, $value, $registered_fields[$key] ] );
+					// Resolve the per-request append flag from the field's sibling control
+					// field, when one was registered (repeaters).
+					$append = false;
+					if ( ! empty( $registered_fields[$key]['append_flag_field'] ) ) {
+						$append = ! empty( $fields_data[ $registered_fields[$key]['append_flag_field'] ] );
+					}
+					call_user_func_array( $registered_fields[$key]['mutate'], [ $object_id, $object_type, $value, $registered_fields[$key], $append ] );
 				}
 				else {
 					$this->update_acf_field_value( $object_id, $object_type, $value, $registered_fields[$key] );
@@ -137,7 +148,7 @@ class Mutations
 	 *
 	 * @return array|null
 	 */
-	private function add_field_group_fields( array $field_group, string $parent_type_name, bool $layout = false ) {
+	private function add_field_group_fields( array $field_group, string $parent_type_name, bool $layout = false, bool $allow_append_flags = true ) {
 
 		/**
 		 * If the field group has the show_in_graphql setting configured, respect it's setting
@@ -212,8 +223,27 @@ class Mutations
 				'acf_field_group' => $field_group,
 			];
 
-			$field_config = $this->register_graphql_field( $config, $parent_type_name );
+			$field_config = $this->register_graphql_field( $config, $parent_type_name, $allow_append_flags );
 			if ( ! empty( $field_config ) ) {
+				// For repeaters, expose an optional sibling flag so a client can choose to
+				// append the provided rows to the existing ones instead of replacing them
+				// (default false). Kept as a separate Boolean field rather than folded into
+				// the repeater input so the repeater's shape is unchanged and existing
+				// queries keep working.
+				if ( $allow_append_flags && isset( $acf_field['type'] ) && 'repeater' === $acf_field['type'] ) {
+					$append_field_name                 = $name . 'Append';
+					$field_config['append_flag_field'] = $append_field_name;
+					$registered_fields[ $append_field_name ] = [
+						'type'           => 'Boolean',
+						'defaultValue'   => false,
+						'description'    => sprintf(
+							/* translators: %s: repeater field name. */
+							__( 'When true, append the provided "%s" rows to the existing rows instead of replacing them. Default false.', 'wp-graphql-acf' ),
+							$name
+						),
+						'is_append_flag' => true,
+					];
+				}
 				$registered_fields[$name] = $field_config;
 			}
 
@@ -252,7 +282,67 @@ class Mutations
 		return apply_filters( 'wpgraphql_acf_filter_mutation_field_value', $filtered_value, $acf_type, $original_value, $field_name, $field_config );
 	}
 
-	private function update_acf_field_value( int $object_id, string $object_type, $value, array $field_config, bool $use_add_row = false ) {
+	/**
+	 * Recursively translate a GraphQL input row into an ACF-keyed row.
+	 *
+	 * ACF matches a repeater/group sub-value by the sub-field's key or ACF (snake_case)
+	 * name, never by the GraphQL (camelCase) field name the input arrives with. Nested
+	 * repeaters and groups are re-keyed recursively here because a parent repeater saves
+	 * them wholesale rather than through their own mutate handler.
+	 */
+	private function normalize_acf_row( array $row, array $sub_fields_config ) {
+		$row_value = [];
+		foreach ( $row as $sub_field_key => $sub_field_value ) {
+			$sub_field_config = isset( $sub_fields_config[ $sub_field_key ] ) ? $sub_fields_config[ $sub_field_key ] : null;
+			// Skip unknown keys and non-field control entries (e.g. an "<field>Append" flag).
+			if ( empty( $sub_field_config ) || empty( $sub_field_config['acf_field'] ) ) {
+				continue;
+			}
+			$value = $this->normalize_acf_input( $sub_field_value, $sub_field_config );
+			if ( $value !== null ) {
+				$acf_key = $this->get_field_key( $sub_field_config['acf_field'] );
+				$row_value[ $acf_key ] = $value;
+			}
+		}
+		return $row_value;
+	}
+
+	/**
+	 * Normalize a single field value for saving: recurse into nested repeaters/groups so
+	 * their keys are translated too, otherwise run the leaf value through the filter.
+	 */
+	private function normalize_acf_input( $value, array $field_config ) {
+		// Nested repeater: a list of rows.
+		if ( ! empty( $field_config['repeater_sub_fields_config'] ) ) {
+			if ( ! is_array( $value ) ) {
+				return $value;
+			}
+			$rows = [];
+			foreach ( $value as $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+				$normalized = $this->normalize_acf_row( $row, $field_config['repeater_sub_fields_config'] );
+				if ( ! empty( $normalized ) ) {
+					$rows[] = $normalized;
+				}
+			}
+			return $rows;
+		}
+
+		// Nested group: a single associative row.
+		if ( ! empty( $field_config['sub_fields_config'] ) ) {
+			if ( ! is_array( $value ) ) {
+				return $value;
+			}
+			return $this->normalize_acf_row( $value, $field_config['sub_fields_config'] );
+		}
+
+		// Leaf field: run it through the mutation value filter.
+		return $this->maybe_filter_value( $field_config, $value );
+	}
+
+	private function update_acf_field_value( int $object_id, string $object_type, $value, array $field_config, string $mode = 'update' ) {
 
 		switch ( $object_type ) {
 			case self::TERM_OBJECT_TYPE:
@@ -290,13 +380,33 @@ class Mutations
 
 		$value = $this->maybe_filter_value( $field_config, $value );
 
-		if ( $value !== null ) {
-			if ( $use_add_row ) {
+		if ( $value === null ) {
+			return;
+		}
+
+		switch ( $mode ) {
+			case 'add_row':
+				// Append a single row to the repeater's existing rows.
 				add_row( $key, $value, $object_id );
-			}
-			else {
+				break;
+			case 'replace_rows':
+				// Replace all of the repeater's rows with $value (an array of rows); an
+				// empty array clears it. Force ACF's non-paginated update path so the rows
+				// fully replace the existing ones. This mirrors ACF's own add_row(), which
+				// disables pagination before saving; without it a paginated repeater would
+				// append during acf/save_post instead of replacing.
+				$post_id = acf_get_valid_post_id( $object_id );
+				$field   = acf_maybe_get_field( $key, $post_id, false );
+				if ( ! $field ) {
+					update_field( $key, $value, $object_id );
+					break;
+				}
+				$field['pagination'] = false;
+				acf_update_value( is_array( $value ) ? $value : [], $post_id, $field );
+				break;
+			default:
 				update_field( $key, $value, $object_id );
-			}
+				break;
 		}
 	}
 
@@ -316,7 +426,7 @@ class Mutations
 	 *
 	 * @return array|null
 	 */
-	private function register_graphql_field( array $config, string $parent_type_name = '' ) {
+	private function register_graphql_field( array $config, string $parent_type_name = '', bool $allow_append_flags = true ) {
 		$acf_field = isset( $config['acf_field'] ) ? $config['acf_field'] : null;
 		$acf_type  = isset( $acf_field['type'] ) ? $acf_field['type'] : null;
 
@@ -428,7 +538,7 @@ class Mutations
 
 				$field_type_name = $this->prepare_input_type_name( $acf_field['name'], $parent_type_name );
 
-				$sub_fields_config = $this->add_field_group_fields( $acf_field, $field_type_name );
+				$sub_fields_config = $this->add_field_group_fields( $acf_field, $field_type_name, false, $allow_append_flags );
 
 				if ( ! empty( $sub_fields_config ) ) {
 					$this->type_registry->register_input_type(
@@ -449,7 +559,10 @@ class Mutations
 
 				$field_type_name = $this->prepare_input_type_name( $acf_field['name'], $parent_type_name );
 
-				$sub_fields_config = $this->add_field_group_fields( $acf_field, $field_type_name );
+				// A repeater's rows are saved wholesale (not field-by-field), so an append flag
+				// on a repeater nested in these rows could never be threaded to it. Disable flag
+				// registration for everything below to keep it out of the row input type.
+				$sub_fields_config = $this->add_field_group_fields( $acf_field, $field_type_name, false, false );
 
 				if ( ! empty( $sub_fields_config ) ) {
 					$this->type_registry->register_input_type(
@@ -463,27 +576,38 @@ class Mutations
 					$field_config = [
 						'type' => [ 'list_of' => $field_type_name ],
 						'repeater_sub_fields_config' => $sub_fields_config,
-						'mutate' => function( $object_id, $object_type, $rows, $field_config ) use ( $sub_fields_config ) {
-							if ( ! empty( $rows ) && is_array( $rows ) ) {
-								foreach ( $rows as $row ) {
-									$row_value = [];
-									foreach ( $row as $sub_field_key => $sub_field_value ) {
-										$sub_field_config = $sub_fields_config[$sub_field_key];
-										if ( ! empty( $sub_field_config ) ) {
-											$sub_field_value = $this->maybe_filter_value( $sub_field_config, $sub_field_value );
+						'mutate' => function( $object_id, $object_type, $rows, $field_config, $append = false ) use ( $sub_fields_config ) {
+							// A null/absent value is a no-op (an omitted field must never wipe existing
+							// rows); only an explicit list acts on the field. An empty list clears it.
+							if ( ! is_array( $rows ) ) {
+								return;
+							}
 
-											if ( $sub_field_value !== null ) {
-												$acf_key = $this->get_field_key( $sub_field_config['acf_field'] );
-												$row_value[$acf_key] = $sub_field_value;
-											}
-										}
-									}
-
-									if ( ! empty( $row_value ) ) {
-										$this->update_acf_field_value( $object_id, $object_type, $row_value, $field_config, true );
-									}
+							// Normalize each incoming row into an [ acf_field_key => value ] array, translating
+							// nested repeater/group keys recursively (see normalize_acf_row).
+							$normalized_rows = [];
+							foreach ( $rows as $row ) {
+								if ( ! is_array( $row ) ) {
+									continue;
+								}
+								$row_value = $this->normalize_acf_row( $row, $sub_fields_config );
+								if ( ! empty( $row_value ) ) {
+									$normalized_rows[] = $row_value;
 								}
 							}
+
+							// $append is the per-request "<field>Append" flag (default false => replace).
+							if ( $append ) {
+								// Legacy behaviour: append each provided row to the existing rows.
+								foreach ( $normalized_rows as $row_value ) {
+									$this->update_acf_field_value( $object_id, $object_type, $row_value, $field_config, 'add_row' );
+								}
+								return;
+							}
+
+							// Default behaviour: replace all existing rows with exactly the rows
+							// provided. An explicit empty list clears the repeater.
+							$this->update_acf_field_value( $object_id, $object_type, $normalized_rows, $field_config, 'replace_rows' );
 						},
 					];
 				}

--- a/src/class-mutations.php
+++ b/src/class-mutations.php
@@ -342,7 +342,7 @@ class Mutations
 				$field_config['type'] = 'String';
 				break;
 			case 'radio':
-				$field_type           = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_type           = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field, $parent_type_name );
 				$field_config['type'] = $field_type;
 				break;
 			case 'select':
@@ -352,7 +352,7 @@ class Mutations
 				 * the field will accept a string, but if it is configured to allow
 				 * multiple values it will accept a list of strings
 				 */
-				$field_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field );
+				$field_type = $this->config->register_choices_of_acf_fields_as_enum_type( $acf_field, $parent_type_name );
 				if ( empty( $acf_field['multiple'] ) ) {
 					$field_config['type'] = $field_type;
 				} else {

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.2
+ * Version:           0.6.1
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.2';
+const WPGRAPHQL_ACF_VERSION = '0.6.1';
 
 /**
  * Initialize the plugin

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.1
+ * Version:           0.6.2
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.1';
+const WPGRAPHQL_ACF_VERSION = '0.6.2';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
Support mutations for ACF fields but there's some limitations, this pull request only support the following:
- Posts and Terms mutations
- Only support the following ACF fields:
  - button_group
  - color_picker
  - email
  - text
  - message
  - oembed
  - password
  - wysiwyg
  - url
  - textarea
  - radio
  - select
  - number
  - range
  - true_false
  - date_picker
  - time_picker
  - date_time_picker
  - relationship
  - image
  - file
  - checkbox
  - taxonomy
  - group
  - repeater