### PR TITLE
dev: Add SemVer-compatible updater

### DIFF
--- a/src/Admin/Updater.php
+++ b/src/Admin/Updater.php
@@ -167,7 +167,7 @@ class Updater {
 		}
 
 		// Bail if this is not checking our plugin.
-		if ( ! isset( $args->slug ) || $args->slug !== $this->plugin_config['slug'] ) {
+		if ( ! isset( $args->slug ) || ( $args->slug !== $this->plugin_config['slug'] && $args->slug !== $custom_slug ) ) {
 			return $response;
 		}
 

--- a/src/Admin/Updater.php
+++ b/src/Admin/Updater.php
@@ -72,7 +72,7 @@ class Updater {
 	 */
 	public function disable_autoupdate( $update, $item ) {
 		// Return early if this is not our plugin.
-		if ( $item->slug !== $this->plugin_config['slug'] ) {
+		if ( $item->slug !== $this->plugin_config['slug'] && $item->plugin !== $this->plugin_config['slug'] .'/' .$this->plugin_config['slug'] .'.php') {
 			return $update;
 		}
 
@@ -128,6 +128,7 @@ class Updater {
 		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->new_version = $new_version;
 		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->package     = $download_url;
 		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->zip_url     = $download_url;
+
 
 		return $transient;
 	}

--- a/src/Admin/Updater.php
+++ b/src/Admin/Updater.php
@@ -1,0 +1,411 @@
+<?php
+/**
+ * Uses Semantic Versioning to determine whether the plugin should be updated.
+ *
+ * @package WPGraphQL\ACF\Admin
+ */
+
+namespace WPGraphQL\ACF\Admin;
+
+use const WPGraphQL\ACF\WPGRAPHQL_ACF_VERSION;
+
+/**
+ * Class - Updater
+ */
+class Updater {
+	const PLUGIN_SLUG          = 'wp-graphql-acf';
+	const VERSION_TRANSIENT    = self::PLUGIN_SLUG . '_latest_version';
+	const WPORG_DATA_TRANSIENT = self::PLUGIN_SLUG . '_wporg_data';
+
+	/**
+	 * The version for the update.
+	 *
+	 * @var string
+	 */
+	protected $new_version = '';
+
+	/**
+	 * The plugin config used by the installer.
+	 *
+	 * @var array
+	 */
+	protected $plugin_config;
+
+	/**
+	 * The Plugin data from wordpress.org
+	 *
+	 * @var array
+	 */
+	protected $wporg_data;
+
+	/**
+	 * The class constructor.
+	 */
+	public function __construct() {
+		// Defining this in the constructor makes things easier to mock/test
+		$this->plugin_config = [
+			'plugin_file'        => WPGRAPHQL_ACF_PLUGIN_FILE,
+			'slug'               => self::PLUGIN_SLUG,
+			'proper_folder_name' => self::PLUGIN_SLUG,
+			'api_url'            => 'https://api.wordpress.org/plugins/info/1.0/' . self::PLUGIN_SLUG . '.json',
+			'repo_url'           => 'https://wordpress.org/plugins/' . self::PLUGIN_SLUG,
+		];
+	}
+
+	/**
+	 * Sets up the hooks.
+	 */
+	public function init() : void {
+		add_filter( 'auto_update_plugin', [ $this, 'disable_autoupdate' ], 10, 2 );
+		add_filter( 'pre_set_site_transient_update_plugins', [ $this, 'api_check' ] );
+		add_filter( 'plugins_api_result', [ $this, 'api_result' ], 10, 3 );
+		add_filter( 'upgrader_source_selection', [ $this, 'upgrader_source_selection' ], 10, 2 );
+	}
+
+	/**
+	 * Disable auto updates for major releases of this plugin.
+	 *
+	 * @param bool|null $update Whether to update.
+	 * @param object    $item   The plugin object.
+	 *
+	 * @return bool|null
+	 */
+	public function disable_autoupdate( $update, $item ) {
+		// Return early if this is not our plugin.
+		if ( $item->slug !== $this->plugin_config['slug'] ) {
+			return $update;
+		}
+
+		// Bail if there's no new version.
+		if ( empty( $item->new_version ) ) {
+			return $update;
+		}
+
+		// Get the update type.
+		$update_type = self::get_semver_update_type( $item->new_version, WPGRAPHQL_ACF_VERSION );
+
+		// Non-'major' updates are allowed.
+		if ( 'major' !== $update_type ) {
+			return $update;
+		}
+
+		// Major updates should never happen automatically.
+		return false;
+	}
+
+	/**
+	 * Hooks into the plugin upgrader to get the correct plugin version we want to install.
+	 *
+	 * @param object $transient The plugin upgrader transient.
+	 *
+	 * @return object
+	 */
+	public function api_check( $transient ) {
+		// Clear the transient.
+		delete_site_transient( self::VERSION_TRANSIENT );
+
+		// Get the latest version we allow to be installed from this version.
+		// In the new codebase, we'll just do this on semver-autoupdates.
+		$plugin_data = $this->get_plugin_data();
+		$version     = $plugin_data['Version'];
+		$new_version = $this->get_latest_version();
+
+		// Check if this is a version update.
+		$is_update = version_compare( $new_version, $version, '>' );
+
+		if ( ! $is_update ) {
+			return $transient;
+		}
+
+		// Get the download URL for reuse.
+		$download_url = $this->get_download_url( $new_version );
+
+		// Populate the transient data.
+		if ( ! isset( $transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ] ) ) {
+			$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ] = (object) $this->plugin_config;
+		}
+
+		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->new_version = $new_version;
+		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->package     = $download_url;
+		$transient->response[ WPGRAPHQL_ACF_PLUGIN_FILE ]->zip_url     = $download_url;
+
+		return $transient;
+	}
+
+	/**
+	 * Filters the Installation API response result
+	 *
+	 * @param object|\WP_Error $response The API response object.
+	 * @param string           $action The type of information being requested from the Plugin Installation API.
+	 * @param object           $args Plugin API arguments.
+	 *
+	 * @return object|\WP_Error
+	 */
+	public function api_result( $response, $action, $args ) {
+		// Bail if this is not checking our plugin.
+		if ( ! isset( $args->slug ) || $args->slug !== $this->plugin_config['slug'] ) {
+			return $response;
+		}
+
+		// Get the latest version.
+		$new_version = $this->get_latest_version();
+
+		// Bail if the version is not newer.
+		if ( version_compare( $new_version, $args->version, '<=' ) ) {
+			return $response;
+		}
+
+		// If we're returning a different version than the latest from WP.org, override the response.
+		$response->version       = $new_version;
+		$response->download_link = $this->get_download_url( $new_version );
+
+		// If this is a major update, add a warning.
+		$update_type = self::get_semver_update_type( $new_version, WPGRAPHQL_ACF_VERSION );
+		$warning     = '';
+
+		if ( 'major' === $update_type ) {
+			$warning = sprintf(
+				/* translators: %s: version number. */
+				__( '<h1><span>&#9888;</span>%s</h1>', 'wp-graphql-acf' ),
+				self::get_breaking_change_message( $new_version )
+			);
+		}
+
+		// If there is a warning, append it to each section.
+		if ( '' !== $warning ) {
+			foreach ( $response->sections as $key => $section ) {
+				$response->sections[ $key ] = $warning . $section;
+			}
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Rename the downloaded zip
+	 *
+	 * @param string $source        File source location.
+	 * @param string $remote_source Remote file source location.
+	 *
+	 * @return string|\WP_Error
+	 */
+	public function upgrader_source_selection( $source, $remote_source ) {
+		global $wp_filesystem;
+
+		if ( strstr( $source, '/wp-graphql-acf' ) ) {
+			$corrected_source = trailingslashit( $remote_source ) . trailingslashit( $this->plugin_config['proper_folder_name'] );
+
+			if ( $wp_filesystem->move( $source, $corrected_source, true ) ) {
+				return $corrected_source;
+			} else {
+				return new \WP_Error();
+			}
+		}
+
+		return $source;
+	}
+
+	/**
+	 * Returns the notice to display inline on the plugins page.
+	 *
+	 * @param string $upgrade_type The type of upgrade.
+	 * @param string $message      The message to display.
+	 */
+	public function get_inline_notice( string $upgrade_type, string $message, ) : string {
+		ob_start();
+		?>
+			<div class="wpgraphql_acf_plugin_upgrade_notice extensions_warning <?php echo esc_attr( $upgrade_type ); ?>">
+				<p><?php echo wp_kses_post( $message ); ?></p>
+			</div>
+		<?php
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Returns the notice modal to displace when trying to upgrade.
+	 *
+	 * @param string $upgrade_type The type of upgrade.
+	 * @param string $message      The message to display.
+	 */
+	public function get_modal_notice( string $upgrade_type, string $message ) : string {
+		ob_start();
+		?>
+		<div id="wpgraphql_acf_plugin_upgrade_modal">
+			<div class="wpgraphql_acf_plugin_upgrade_modal--content">
+				<h1><?php esc_html_e( "Are you sure you're ready to upgrade?", 'wp-graphql-acf' ); ?></h1>
+				<div class="wpgraphql_acf_plugin_upgra extensions_warning">
+					<div class="wpgraphql_acf_plugin_upgrade_notice extensions_warning <?php echo esc_attr( $upgrade_type ); ?>">
+						<p><?php echo wp_kses_post( $message ); ?></p>
+					</div>
+
+					<?php if ( current_user_can( 'update_plugins' ) ) : ?>
+						<div class="actions">
+							<a href="#" class="button button-secondary cancel"><?php esc_html_e( 'Cancel', 'wp-graphql-acf' ); ?></a>
+							<a class="button button-primary accept" href="#"><?php esc_html_e( 'Update now', 'wp-graphql-acf' ); ?></a>
+						</div>
+					<?php endif ?>
+				</div>
+			</div>
+		</div>
+
+		<?php
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Gets the plugin data from the headers.
+	 *
+	 * @return array
+	 */
+	protected function get_plugin_data() : array {
+		return get_plugin_data( WPGRAPHQL_ACF_PLUGIN_FILE );
+	}
+
+	/**
+	 * Gets the latest (installable) version of the plugin.
+	 *
+	 * On versions below 1.0.0, we only allow updates up to 1.0.0.
+	 */
+	protected function get_latest_version() : string {
+		$latest_version = get_site_transient( self::VERSION_TRANSIENT );
+
+		if ( empty( $latest_version ) ) {
+			$data = $this->get_wporg_data();
+
+			/** @var string $latest_version */
+			$latest_version = $data['version'] ?? '';
+
+			/** @var array<string,string> $versions */
+			$versions = $data['versions'] ?? [];
+
+
+			foreach ( $versions as $version => $download_url ) {
+				// Skip trunk.
+				if ( 'trunk' === $version ) {
+					continue;
+				}
+
+				// If the current version is < 1.0.0, but this version is >= 2, skip it.
+				// @phpstan-ignore-next-line
+				if ( version_compare( WPGRAPHQL_ACF_VERSION, '1.0.0', '<' ) && version_compare( $version, '2.0.0', '>=' ) ) {
+					continue;
+				}
+				
+				// Return the first matching version.
+				$latest_version = $version;
+			}
+
+			if ( ! empty( $latest_version ) ) {
+				set_site_transient( self::VERSION_TRANSIENT, $latest_version, 6 * HOUR_IN_SECONDS );
+			}
+		}
+
+		return $latest_version;
+	}
+
+	/**
+	 * Gets the data from the WordPress plugin directory.
+	 *
+	 * @return array<string,mixed>
+	 */
+	protected function get_wporg_data() : array {
+		// Return cached data if available.
+		if ( ! empty( $this->wporg_data ) ) {
+			return $this->wporg_data;
+		}
+
+		// Get data from transient.
+		$data = get_site_transient( self::WPORG_DATA_TRANSIENT );
+
+		if ( empty( $data ) || ! is_array( $data ) ) {
+			$data = wp_remote_get( $this->plugin_config['api_url'] ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get
+
+			$body = wp_remote_retrieve_body( $data );
+
+			// Bail because we couldn't parse the body.
+			if ( empty( $body ) ) {
+				return [];
+			}
+
+			$data = json_decode( $body, true );
+
+			// Bail because we couldn't decode the body.
+			if ( empty( $data ) || ! is_array( $data ) ) {
+				return [];
+			}
+
+			// Refresh every 6 hours.
+			set_site_transient( self::WPORG_DATA_TRANSIENT, $data, 6 * HOUR_IN_SECONDS );
+		}
+
+		// Stash for reuse.
+		$this->wporg_data = $data;
+
+		return $data;
+	}
+
+	/**
+	 * Gets the download URL for a specific version.
+	 *
+	 * @param string $version Version number.
+	 *
+	 * @return string|false
+	 */
+	protected function get_download_url( string $version ) {
+		$data = $this->get_wporg_data();
+
+		if ( empty( $data['versions'][ $version ] ) ) {
+			return false;
+		}
+
+		return $data['versions'][ $version ];
+	}
+
+	/**
+	 * Returns the SemVer type of update based on the new version.
+	 *
+	 * @param string $new_version The SemVer-compliant version number (x.y.z)
+	 * @param string $current_version The SemVer-compliant version number (x.y.z)
+	 * 
+	 * @return string{major|minor|patch} The type of update (major, minor, patch).
+	 */
+	protected static function get_semver_update_type( string $new_version, string $current_version ) : string {
+		$current = explode( '.', $current_version );
+		$new     = explode( '.', $new_version );
+
+		// If the first digit is 0, we need to compare the next digit.
+		if ( '0' === $new[0] && '0' !== $current[0] ) {
+			return self::get_semver_update_type(
+				implode( '.', array_slice( $new, 1 ) ),
+				implode( '.', array_slice( $current, 1 ) )
+			);
+		}
+
+		// If the major version is different, this is a major update.
+		if ( $current[0] !== $new[0] ) {
+			return 'major';
+		}
+
+		// If the minor version is different, this is a minor update.
+		if ( $current[1] !== $new[1] ) {
+			return 'minor';
+		}
+
+		return 'patch';
+	}
+
+	/**
+	 * Gets the message to display for a breaking change.
+	 *
+	 * @param string $version The version number.
+	 */
+	protected static function get_breaking_change_message( string $version ) : string {
+		return sprintf(
+			/* translators: %s: version number. */
+			__( 'Version %s of WPGraphQL for ACF is a major update and may contain breaking changes. Please review the changelog and test before updating on a production site.', 'wp-graphql-acf' ),
+			$version
+		);
+	}
+
+}

--- a/src/class-acf.php
+++ b/src/class-acf.php
@@ -84,20 +84,22 @@ final class ACF {
 	 * @return void
 	 */
 	private function setup_constants() {
+		$main_file_path = dirname( __DIR__ ) . '/wp-graphql-acf.php';
+
 
 		// Plugin Folder Path.
 		if ( ! defined( 'WPGRAPHQL_ACF_PLUGIN_DIR' ) ) {
-			define( 'WPGRAPHQL_ACF_PLUGIN_DIR', plugin_dir_path( __FILE__ . '/..' ) );
+			define( 'WPGRAPHQL_ACF_PLUGIN_DIR', plugin_dir_path( $main_file_path ) );
 		}
 
 		// Plugin Folder URL.
 		if ( ! defined( 'WPGRAPHQL_ACF_PLUGIN_URL' ) ) {
-			define( 'WPGRAPHQL_ACF_PLUGIN_URL', plugin_dir_url( __FILE__ . '/..' ) );
+			define( 'WPGRAPHQL_ACF_PLUGIN_URL', plugin_dir_url( $main_file_path ) );
 		}
 
 		// Plugin Root File.
 		if ( ! defined( 'WPGRAPHQL_ACF_PLUGIN_FILE' ) ) {
-			define( 'WPGRAPHQL_ACF_PLUGIN_FILE', __FILE__ . '/..' );
+			define( 'WPGRAPHQL_ACF_PLUGIN_FILE', $main_file_path );
 		}
 	}
 

--- a/src/class-acf.php
+++ b/src/class-acf.php
@@ -8,6 +8,7 @@
 namespace WPGraphQL\ACF;
 
 use GraphQL\Type\Definition\ResolveInfo;
+use WPGraphQL\ACF\Admin\Updater;
 
 /**
  * Final class ACF
@@ -17,7 +18,7 @@ final class ACF {
 	/**
 	 * Stores the instance of the WPGraphQL\ACF class
 	 *
-	 * @var ACF The one true WPGraphQL\Extensions\ACF
+	 * @var \WPGraphQL\ACF\ACF The one true WPGraphQL\Extensions\ACF
 	 * @access private
 	 */
 	private static $instance;
@@ -25,12 +26,11 @@ final class ACF {
 	/**
 	 * Get the singleton.
 	 *
-	 * @return ACF
+	 * @return \WPGraphQL\ACF\ACF
 	 */
 	public static function instance() {
-
-		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof ACF ) ) {
-			self::$instance = new ACF();
+		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof self ) ) {
+			self::$instance = new self();
 			self::$instance->setup_constants();
 			self::$instance->includes();
 			self::$instance->actions();
@@ -41,7 +41,7 @@ final class ACF {
 		/**
 		 * Fire off init action
 		 *
-		 * @param ACF $instance The instance of the WPGraphQL\ACF class
+		 * @param \WPGraphQL\ACF\ACF $instance The instance of the WPGraphQL\ACF class
 		 */
 		do_action( 'graphql_acf_init', self::$instance );
 
@@ -63,7 +63,6 @@ final class ACF {
 
 		// Cloning instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'The \WPGraphQL\ACF class should not be cloned.', 'wp-graphql-acf' ), '0.0.1' );
-
 	}
 
 	/**
@@ -76,7 +75,6 @@ final class ACF {
 
 		// De-serializing instances of the class is forbidden.
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'De-serializing instances of the \WPGraphQL\ACF class is not allowed', 'wp-graphql-acf' ), '0.0.1' );
-
 	}
 
 	/**
@@ -101,7 +99,6 @@ final class ACF {
 		if ( ! defined( 'WPGRAPHQL_ACF_PLUGIN_FILE' ) ) {
 			define( 'WPGRAPHQL_ACF_PLUGIN_FILE', __FILE__ . '/..' );
 		}
-
 	}
 
 	/**
@@ -121,7 +118,6 @@ final class ACF {
 	 * cycle
 	 */
 	private function actions() {
-
 	}
 
 	/**
@@ -133,28 +129,33 @@ final class ACF {
 		 * This filters any field that returns the `ContentTemplate` type
 		 * to pass the source node down to the template for added context
 		 */
-		add_filter( 'graphql_resolve_field', function( $result, $source, $args, $context, ResolveInfo $info, $type_name, $field_key, $field, $field_resolver ) {
-			if ( isset( $info->returnType ) && strtolower( 'ContentTemplate' ) === strtolower( $info->returnType ) ) {
-				if ( is_array( $result ) && ! isset( $result['node'] ) && ! empty( $source ) ) {
-					$result['node'] = $source;
+		add_filter(
+			'graphql_resolve_field',
+			static function ( $result, $source, $args, $context, ResolveInfo $info, $type_name, $field_key, $field, $field_resolver ) {
+				if ( isset( $info->returnType ) && strtolower( 'ContentTemplate' ) === strtolower( $info->returnType ) ) {
+					if ( is_array( $result ) && ! isset( $result['node'] ) && ! empty( $source ) ) {
+						$result['node'] = $source;
+					}
 				}
-			}
-			return $result;
-		}, 10, 9 );
-
+				return $result;
+			},
+			10,
+			9 
+		);
 	}
 
 	/**
 	 * Initialize
 	 */
 	private function init() {
-
 		$config = new Config();
 		add_action( 'graphql_register_types', [ $config, 'init' ], 10, 1 );
 
 		$acf_settings = new ACF_Settings();
 		$acf_settings->init();
 
+		$updater = new Updater();
+		$updater->init();
 	}
 
 }


### PR DESCRIPTION
This PR (wip) adds a forward-compatible plugin updater to help transition to the new `wp-graphql/wpgraphql-acf` version and WordPress.org distribution.

When completed the plugin will
- Disable auto-updates for breaking releases.
- Display an inline-notice on the Upgrades/Plugins screen when a plugin update is a breaking release.
- Add a confirmation modal when upgrading is a breaking release.
- Preventing updating from `v0.x.y` to `v2.x.y`, so the 2.0 release on wp.org doesnt autoupdate to a breaking change.

#### To do
- [x] Backport and scaffold `Updater` class.
- [ ] Add thickbox model controls and styling.
- [ ] (Maybe) Add mechanism to auto-downgrade from v2.0 to v1.x if autoupdated from a version without this `Updater` functionality.
- [ ] Test.
- [ ] Repurpose for 2.x codebase

### Release process:
1. This should be pushed in a `0.x.Y` release (to catch anyone installing with composer).
2. A cosmetic `v1.0` release will be pushed as the first WordPress.org release (to catch anyone using WordPress's autoupdater)
3. The new v2.0 codebase in https://github.com/wp-graphql/wpgraphql-acf will then be released to WordPress.org, where a warning about the breaking changes will be included (and users will be prompted to confirm before updating).
4. (Maybe) if a user autoupdates from < 0.current to 2.0, they will be automatically downgraded to v1.0 (step 2+3)

### To test:
Since the plugin is not yet on WP.org, we can use the following filters to test. This essentially 'tricks' WordPress into thinking that the latest _WPGraphQL core_ update is actually for our plugin.

```php
//Disable after testing.
add_filter( 'plugins_api_args', static function ( $args ) {
	if ( isset( $args->slug ) && $args->slug === 'wp-graphql-acf' ) {
		$args->slug = 'wp-graphql';
	}

	return $args;
} );
add_filter( 'wpgraphql_acf_wporg_api_url', static function () {
	return 'https://api.wordpress.org/plugins/info/1.0/wp-graphql.json';
}  );
add_filter( 'wpgraphql_acf_wporg_api_result_slug', static function ( $slug, $args ) {
	return 'wp-graphql';
}, 10, 2  );
``` 

### Screenshots
1. Update screen notice:
![image](https://github.com/wp-graphql/wp-graphql-acf/assets/29322304/1d891566-2b01-433c-935c-08d0c2b19e57)
2. Update screen modal : todo
3. Plugin screen notice:
![image](https://github.com/wp-graphql/wp-graphql-acf/assets/29322304/00b04168-c1ce-4519-9694-1eaa7a94a17b)
4. Plugin information modal notice (appears on every tab)
![image](https://github.com/wp-graphql/wp-graphql-acf/assets/29322304/04e66a99-2200-419e-92ac-7f2cd3e2fc03)

