### PR TITLE
release: v0.6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,11 @@ SEE: https://github.com/wp-graphql/wp-graphql-acf/releases
 
 == Upgrade Notice ==
 
+= 0.6.2 =
+
+NOTE: This is the final release of this plugin. Please migrate to the [new WPGraphQL for ACF](https://github.com/wp-graphql/wpgraphql-acf) at your earliest convenience.
+
+
 = 0.1.1 =
 ACF Field groups were not properly being added to the GraphQL Schema for Custom Post Types. This
 addresses that issue, so now Field groups that are set to "show_in_graphql" and are assigned to a

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://wpgraphql.com/acf
 Tags: WPGraphQL, GraphQL, API, Advanced Custom Fields, ACF
 Requires at least: 5.0
 Tested up to: 5.1.1
-Stable tag: 0.6.1
+Stable tag: 0.6.2
 License: GPL-3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/wp-graphql-acf.php
+++ b/wp-graphql-acf.php
@@ -7,7 +7,7 @@
  * Author URI:        https://www.wpgraphql.com
  * Text Domain:       wp-graphql-acf
  * Domain Path:       /languages
- * Version:           0.6.1
+ * Version:           0.6.2
  * Requires PHP:      7.0
  * GitHub Plugin URI: https://github.com/wp-graphql/wp-graphql-acf
  *
@@ -26,7 +26,7 @@ require_once( __DIR__ . '/vendor/autoload.php' );
  * Define constants
  */
 const WPGRAPHQL_REQUIRED_MIN_VERSION = '0.4.0';
-const WPGRAPHQL_ACF_VERSION = '0.6.1';
+const WPGRAPHQL_ACF_VERSION = '0.6.2';
 
 /**
  * Initialize the plugin


### PR DESCRIPTION
**NOTE**: This is the final release of this plugin. Please migrate to the [new WPGraphQL for ACF](https://github.com/wp-graphql/wpgraphql-acf) at your earliest convenience.

----

This replaces deprecated `DataSource` methods with their corresponding Loader methods.